### PR TITLE
Fix typo

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -3,7 +3,7 @@
     "name": "hof",
     "authors": [ "Paul Fultz II" ],
     "maintainers": [ "Paul Fultz II <pfultz2 -at- yahoo.com>" ],
-    "description": "Higer-order functions for C++",
+    "description": "Higher-order functions for C++",
     "category": [
         "Metaprogramming"
     ]


### PR DESCRIPTION
You might also want to change the name to 'Hof' or 'HOF', as most library names start with a capital.