### PR TITLE
Support newer version of Sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -422,6 +422,8 @@ extract_prefix = '/// '
 include_dir = os.path.abspath('../include/')
 def extract_doc(app, docname, source):
     path = app.env.doc2path(docname)
+    if sphinxversion != "1":
+        source[0] = source[0].replace('```eval_rst', '```{eval-rst}')
     if path.endswith('.hpp'):
         lines = source[0].split('\n')
         md = [line[len(extract_prefix):] for line in lines if line.startswith(extract_prefix)]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,8 +23,15 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-from recommonmark.parser import CommonMarkParser
-from recommonmark.transform import AutoStructify
+import sphinx as sphinxversioncheck
+from pkg_resources import parse_version
+sphinxversion=""
+if parse_version(sphinxversioncheck.__version__) < parse_version("2.0.0"):
+    sphinxversion="1"
+
+if sphinxversion=="1":
+    from recommonmark.parser import CommonMarkParser
+    from recommonmark.transform import AutoStructify
 import sphinx_boost
 
 # -- General configuration ------------------------------------------------
@@ -36,25 +43,41 @@ import sphinx_boost
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    # 'sphinx.ext.autodoc',
-    # 'sphinx.ext.githubpages',
-    'sphinx.ext.autosectionlabel',
-]
+if sphinxversion=="1":
+    extensions = [
+        # 'sphinx.ext.autodoc',
+        # 'sphinx.ext.githubpages',
+        'sphinx.ext.autosectionlabel',
+    ]
+else:
+    extensions = [
+        'sphinx.ext.autosectionlabel',
+        'myst_parser'
+    ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-source_parsers = {
-    '.md': CommonMarkParser,
-    '.hpp': CommonMarkParser
-}
+if sphinxversion=="1":
+    source_parsers = {
+        '.md': CommonMarkParser,
+        '.hpp': CommonMarkParser
+    }
+else:
+    source_parsers = {}
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = ['.rst', '.md', '.hpp']
-# source_suffix = '.rst'
+if sphinxversion=="1":
+    source_suffix = ['.rst', '.md', '.hpp']
+else:
+    source_suffix = {
+        '.rst': 'restructuredtext',
+        '.txt': 'markdown',
+        '.md': 'markdown',
+        '.hpp': 'markdown',
+    }
 
 # The encoding of source files.
 #
@@ -407,10 +430,11 @@ def extract_doc(app, docname, source):
 # app setup hook
 def setup(app):
     app.srcdir = os.path.abspath(os.path.join(app.srcdir, os.pardir))
-    app.add_config_value('recommonmark_config', {
-            'enable_eval_rst': True,
-            # 'enable_auto_doc_ref': True,
-            'commonmark_suffixes': ['.md', '.hpp'],
-            }, True)
-    app.add_transform(AutoStructify)
+    if sphinxversion=="1":
+        app.add_config_value('recommonmark_config', {
+                'enable_eval_rst': True,
+                # 'enable_auto_doc_ref': True,
+                'commonmark_suffixes': ['.md', '.hpp'],
+                }, True)
+        app.add_transform(AutoStructify)
     app.connect('source-read', extract_doc)

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,6 @@
 #    Distributed under the Boost Software License, Version 1.0. (See accompanying
 #    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #==============================================================================
-sphinx>=1.5,<1.6
-# recommonmark==0.4.0
-git+https://github.com/pfultz2/recommonmark@develop
-sphinx-boost>0.0.2
+sphinx==5.2.1
+myst-parser==0.18.1
+git+https://github.com/pfultz2/sphinx-boost@8ad7d424c6b613864976546d801439c34a27e3f6


### PR DESCRIPTION
Hi,

The current boostorg/boost bundle has been created using Sphinx version 1.5.6 

If upgrading _all_ packages and Sphinx changes to 5.2.1 , the hof docs are slightly broken. 

- No code blocks
- bullet lists are widely spaced   

Researched the problems in https://github.com/sphinx-doc/sphinx/issues .  Ultimately the best solution seems to be switching to the recommended package https://github.com/executablebooks/MyST-Parser because "recommonmark is now deprecated."   The way forward is myst-parser.    The update in this pull request it is detecting if the sphinx version is still 1.5.6, in which case the old methodology continues to be used, or if a newer sphinx, then switch to myst-parser.   

The code blocks which were missing, reappear.  So that is a good result.  However, what's interesting is that some of those blocks are highlighted correctly and others are plain without color highlighting.  What is the cause of that?  It seems in the source files that some blocks are marked with backticks and the language "cpp".   Those are rendered.   And in the cases without backticks and language, there is no color.    Even if this is not ideal, at least there is a work-around available: go and  mark those code blocks with backticks, if they should have color highlighting.

In terms of "bullet lists are widely spaced" I will send another pull request to the sphinx-boost repository.  
