### PR TITLE
Add fenced code blocks in documentation

### DIFF
--- a/doc/src/building.md
+++ b/doc/src/building.md
@@ -8,39 +8,51 @@ Building
 
 Boost.HigherOrderFunctions library uses cmake to build. To configure with cmake create a build directory, and run cmake:
 
-    mkdir build
-    cd build
-    cmake ..
+```cpp
+mkdir build
+cd build
+cmake ..
+```
 
 Installing
 ----------
 
 To install the library just run the `install` target:
 
-    cmake --build . --target install
+```cpp
+cmake --build . --target install
+```
 
 Tests
 -----
 
 The tests can be built and run by using the `check` target:
 
-    cmake --build . --target check
+```cpp
+cmake --build . --target check
+```
 
 The tests can also be ran using Boost.Build, just copy library to the boost source tree, and then:
 
-    cd test
-    b2
+```cpp
+cd test
+b2
+```
 
 Documentation
 -------------
 
 The documentation is built using Sphinx. First, install the requirements needed for the documentation using `pip`:
 
-    pip install -r doc/requirements.txt
+```cpp
+pip install -r doc/requirements.txt
+```
 
 Then html documentation can be generated using `sphinx-build`:
 
-    sphinx-build -b html doc/ doc/html/
+```cpp
+sphinx-build -b html doc/ doc/html/
+```
 
 The final docs will be in the `doc/html` folder.
 

--- a/doc/src/example_overloading.md
+++ b/doc/src/example_overloading.md
@@ -19,41 +19,47 @@ and fallback on using `sstream` to convert to a string. Most of the top
 answers usually involve some amount of metaprogramming using either `void_t`
 or `is_detected`(see [n4502](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4502.pdf)): 
 
-    template<class T>
-    using to_string_t = decltype(std::to_string(std::declval<T>()));
+```cpp
+template<class T>
+using to_string_t = decltype(std::to_string(std::declval<T>()));
 
-    template<class T>
-    using has_to_string = std::experimental::is_detected<to_string_t, T>;
+template<class T>
+using has_to_string = std::experimental::is_detected<to_string_t, T>;
 
-    template<typename T> 
-    typename std::enable_if<has_to_string<T>{}, std::string>::type 
-    stringify(T t)
-    {
-        return std::to_string(t);
-    }
-    template<typename T> 
-    typename std::enable_if<!has_to_string<T>{}, std::string>::type 
-    stringify(T t)
-    {
-        return static_cast<std::ostringstream&>(std::ostringstream() << t).str();
-    }
+template<typename T> 
+typename std::enable_if<has_to_string<T>{}, std::string>::type 
+stringify(T t)
+{
+    return std::to_string(t);
+}
+template<typename T> 
+typename std::enable_if<!has_to_string<T>{}, std::string>::type 
+stringify(T t)
+{
+    return static_cast<std::ostringstream&>(std::ostringstream() << t).str();
+}
+```
 
 However, with Boost.HigherOrderFunctions it can simply be written like
 this:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(stringify) = first_of(
-        [](auto x) BOOST_HOF_RETURNS(std::to_string(x)),
-        [](auto x) BOOST_HOF_RETURNS(static_cast<std::ostringstream&>(std::ostringstream() << x).str())
-    );
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(stringify) = first_of(
+    [](auto x) BOOST_HOF_RETURNS(std::to_string(x)),
+    [](auto x) BOOST_HOF_RETURNS(static_cast<std::ostringstream&>(std::ostringstream() << x).str())
+);
+```
 
 So, using [`BOOST_HOF_RETURNS`](/include/boost/hof/returns) not only deduces the return type for the function, but it also constrains the function on whether the expression is valid or not. So by writing `BOOST_HOF_RETURNS(std::to_string(x))` then the first function will try to call `std::to_string` function if possible. If not, then the second function will be called. 
 
 The second function still uses [`BOOST_HOF_RETURNS`](/include/boost/hof/returns), so the function will still be constrained by whether the `<<` stream operator can be used. Although it may seem unnecessary because there is not another function, however, this makes the function composable. So we could use this to define a `serialize` function that tries to call `stringify` first, otherwise it looks for the member `.serialize()`:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(serialize) = first_of(
-        [](auto x) BOOST_HOF_RETURNS(stringify(x)),
-        [](auto x) BOOST_HOF_RETURNS(x.serialize())
-    );
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(serialize) = first_of(
+    [](auto x) BOOST_HOF_RETURNS(stringify(x)),
+    [](auto x) BOOST_HOF_RETURNS(x.serialize())
+);
+```
 
 static_if
 ---------
@@ -63,30 +69,34 @@ constructs on pre-C++17 compilers. For example, Baptiste Wicht discusses how one
 
 He wants to be able to write this:
 
-    template<typename T>
-    void decrement_kindof(T& value){
-        if constexpr(std::is_same<std::string, T>()){
-            value.pop_back();
-        } else {
-            --value;
-        }
+```cpp
+template<typename T>
+void decrement_kindof(T& value){
+    if constexpr(std::is_same<std::string, T>()){
+        value.pop_back();
+    } else {
+        --value;
     }
+}
+```
 
 However, that isn't possible before C++17. With Boost.HigherOrderFunctions one can simply write
 this:
 
-    template<typename T>
-    void decrement_kindof(T& value)
-    {
-        eval(first_of(
-            if_(std::is_same<std::string, T>())([&](auto id){
-                id(value).pop_back();
-            }),
-            [&](auto id){
-                --id(value);
-            }
-        ));
-    }
+```cpp
+template<typename T>
+void decrement_kindof(T& value)
+{
+    eval(first_of(
+        if_(std::is_same<std::string, T>())([&](auto id){
+            id(value).pop_back();
+        }),
+        [&](auto id){
+            --id(value);
+        }
+    ));
+}
+```
 
 The `id` parameter passed to the lambda is the [`identity`](/include/boost/hof/identity) function. As explained in the article, this is used to delay the lookup of types by making it a dependent type(i.e. the type depends on a template parameter), which is necessary to avoid compile errors. The [`eval`](/include/boost/hof/eval) function that is called will pass this `identity` function to the lambdas.
 
@@ -95,21 +105,23 @@ Wicht's blog, is that [`first_of`](/include/boost/hof/conditional) allows more t
 there was another trait to be checked, such as `is_stack`, it could be written
 like this:
 
-    template<typename T>
-    void decrement_kindof(T& value)
-    {
-        eval(first_of(
-            if_(is_stack<T>())([&](auto id){
-                id(value).pop();
-            }),
-            if_(std::is_same<std::string, T>())([&](auto id){
-                id(value).pop_back();
-            }),
-            [&](auto id){
-                --id(value);
-            }
-        ));
-    }
+```cpp
+template<typename T>
+void decrement_kindof(T& value)
+{
+    eval(first_of(
+        if_(is_stack<T>())([&](auto id){
+            id(value).pop();
+        }),
+        if_(std::is_same<std::string, T>())([&](auto id){
+            id(value).pop_back();
+        }),
+        [&](auto id){
+            --id(value);
+        }
+    ));
+}
+```
 
 Type traits
 -----------
@@ -119,24 +131,26 @@ Weller was looking for a way to define a general purpose detection for pointer
 operands(such as `*` and `->`). One way to accomplish this is like
 this:
 
-    // Check that T has member function for operator* and ope
-    template<class T>
-    auto has_pointer_member(const T&) -> decltype(
-        &T::operator*,
-        &T::operator->,
-        std::true_type{}
-    );
+```cpp
+// Check that T has member function for operator* and ope
+template<class T>
+auto has_pointer_member(const T&) -> decltype(
+    &T::operator*,
+    &T::operator->,
+    std::true_type{}
+);
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(has_pointer_operators) = first_of(
-        BOOST_HOF_LIFT(has_pointer_member),
-        [](auto* x) -> bool_constant<(!std::is_void<decltype(*x)>())> { return {}; },
-        always(std::false_type{})
-    );
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(has_pointer_operators) = first_of(
+    BOOST_HOF_LIFT(has_pointer_member),
+    [](auto* x) -> bool_constant<(!std::is_void<decltype(*x)>())> { return {}; },
+    always(std::false_type{})
+);
 
-    template<class T>
-    struct is_dereferenceable
-    : decltype(has_pointer_operators(std::declval<T>()))
-    {};
+template<class T>
+struct is_dereferenceable
+: decltype(has_pointer_operators(std::declval<T>()))
+{};
+```
 
 Which is much simpler than the other implementations that were written, which were
 about 3 times the amount of code(see [here](https://gist.github.com/lefticus/6fdccb18084a1a3410d5)).

--- a/doc/src/example_polymorphic_constructors.md
+++ b/doc/src/example_polymorphic_constructors.md
@@ -9,29 +9,34 @@ Polymorphic constructors
 Writing polymorphic constructors(such as `make_tuple`) is a boilerplate that
 has to be written over and over again for template classes: 
 
-    template <class T>
-    struct unwrap_refwrapper
-    {
-        typedef T type;
-    };
-     
-    template <class T>
-    struct unwrap_refwrapper<std::reference_wrapper<T>>
-    {
-        typedef T& type;
-    };
-     
-    template <class T>
-    struct unwrap_ref_decay
-    : unwrap_refwrapper<typename std::decay<T>::type>
-    {};
+```cpp
+template <class T>
+struct unwrap_refwrapper
+{
+    typedef T type;
+};
+ 
+template <class T>
+struct unwrap_refwrapper<std::reference_wrapper<T>>
+{
+    typedef T& type;
+};
+ 
+template <class T>
+struct unwrap_ref_decay
+: unwrap_refwrapper<typename std::decay<T>::type>
+{};
 
-    template <class... Types>
-    std::tuple<typename unwrap_ref_decay<Types>::type...> make_tuple(Types&&... args)
-    {
-        return std::tuple<typename unwrap_ref_decay<Types>::type...>(std::forward<Types>(args)...);
-    }
+template <class... Types>
+std::tuple<typename unwrap_ref_decay<Types>::type...> make_tuple(Types&&... args)
+{
+    return std::tuple<typename unwrap_ref_decay<Types>::type...>(std::forward<Types>(args)...);
+}
+```
 
 The [`construct`](include/boost/hof/construct) function takes care of all this boilerplate, and the above can be simply written like this:
 
-    BOOST_HOF_STATIC_FUNCTION(make_tuple) = construct<std::tuple>();
+```cpp
+BOOST_HOF_STATIC_FUNCTION(make_tuple) = construct<std::tuple>();
+```
+

--- a/doc/src/example_print.md
+++ b/doc/src/example_print.md
@@ -8,10 +8,12 @@ Print function
 
 Say, for example, we would like to write a print function. We could start by writing the function that prints using `std::cout`, like this:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = [](const auto& x)
-    {
-        std::cout << x << std::endl;
-    };
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = [](const auto& x)
+{
+    std::cout << x << std::endl;
+};
+```
 
 However, there is lot of things that don't print directly to `std::cout` such as `std::vector` or `std::tuple`. Instead, we want to iterate over these data structures and print each element in them.
 
@@ -20,112 +22,135 @@ Overloading
 
 Boost.HigherOrderFunctions provides several ways to do overloading. One of the ways is with the [`first_of`](/include/boost/hof/conditional) adaptor which will pick the first function that is callable. This allows ordering the functions based on which one is more important. So then the first function will print to `std::cout` if possible otherwise we will add an overload to print a range:
 
-
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = first_of(
-        [](const auto& x) -> decltype(std::cout << x, void())
-        {
-            std::cout << x << std::endl;
-        },
-        [](const auto& range)
-        {
-            for(const auto& x:range) std::cout << x << std::endl;
-        }
-    );
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = first_of(
+    [](const auto& x) -> decltype(std::cout << x, void())
+    {
+        std::cout << x << std::endl;
+    },
+    [](const auto& range)
+    {
+        for(const auto& x:range) std::cout << x << std::endl;
+    }
+);
+```
 
 The `-> decltype(std::cout << x, void())` is added to the function to constrain it on whether `std::cout << x` is a valid expression. Then the `void()` is used to return `void` from the function. So, now the function can be called with a vector:
 
-    std::vector<int> v = { 1, 2, 3, 4 };
-    print(v);
+```cpp
+std::vector<int> v = { 1, 2, 3, 4 };
+print(v);
+```
 
 This will print each element in the vector. 
 
 We can also constrain the second overload as well, which will be important to add more overloads. So a `for` range loop calls `begin` and `end` to iterated over the range, but we will need some helper function in order to call `std::begin` using ADL lookup:
 
-    namespace adl {
+```cpp
+namespace adl {
 
-    using std::begin;
+using std::begin;
 
-    template<class R>
-    auto adl_begin(R&& r) BOOST_HOF_RETURNS(begin(r));
-    }
+template<class R>
+auto adl_begin(R&& r) BOOST_HOF_RETURNS(begin(r));
+}
+```
 
 Now we can add `-> decltype(std::cout << *adl::adl_begin(range), void())` to the second function to constrain it to ranges:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = first_of(
-        [](const auto& x) -> decltype(std::cout << x, void())
-        {
-            std::cout << x << std::endl;
-        },
-        [](const auto& range) -> decltype(std::cout << *adl::adl_begin(range), void())
-        {
-            for(const auto& x:range) std::cout << x << std::endl;
-        }
-    );
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = first_of(
+    [](const auto& x) -> decltype(std::cout << x, void())
+    {
+        std::cout << x << std::endl;
+    },
+    [](const auto& range) -> decltype(std::cout << *adl::adl_begin(range), void())
+    {
+        for(const auto& x:range) std::cout << x << std::endl;
+    }
+);
+```
 
 So now calling this will work:
 
-    std::vector<int> v = { 1, 2, 3, 4 };
-    print(v);
+```cpp
+std::vector<int> v = { 1, 2, 3, 4 };
+print(v);
+```
 
 And print out:
 
-    1
-    2
-    3
-    4
+```cpp
+1
+2
+3
+4
+```
 
 Tuples
 ------
 
 We could extend this to printing tuples as well. We will need to combine a couple of functions to make a `for_each_tuple`, which lets us call a function for each element. First, the [`proj`](/include/boost/hof/by) adaptor will let us apply a function to each argument passed in, and the [`unpack`](/include/boost/hof/unpack) adaptor will unpack the elements of a tuple and apply them to the function:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(for_each_tuple) = [](const auto& sequence, auto f)
-    {
-        return unpack(proj(f))(sequence);
-    };
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(for_each_tuple) = [](const auto& sequence, auto f)
+{
+    return unpack(proj(f))(sequence);
+};
+```
 
 So now if we call:
 
-    for_each_tuple(std::make_tuple(1, 2, 3), [](auto i)
-    {
-        std::cout << i << std::endl;
-    });
+```cpp
+for_each_tuple(std::make_tuple(1, 2, 3), [](auto i)
+{
+    std::cout << i << std::endl;
+});
+```
 
 This will print out:
 
-    1
-    2
-    3
+```cpp
+1
+2
+3
+```
 
 We can integrate this into our `print` function by adding an additional overload:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = first_of(
-        [](const auto& x) -> decltype(std::cout << x, void())
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = first_of(
+    [](const auto& x) -> decltype(std::cout << x, void())
+    {
+        std::cout << x << std::endl;
+    },
+    [](const auto& range) -> decltype(std::cout << *adl::adl_begin(range), void())
+    {
+        for(const auto& x:range) std::cout << x << std::endl;
+    },
+    [](const auto& tuple)
+    {
+        for_each_tuple(tuple, [](const auto& x)
         {
             std::cout << x << std::endl;
-        },
-        [](const auto& range) -> decltype(std::cout << *adl::adl_begin(range), void())
-        {
-            for(const auto& x:range) std::cout << x << std::endl;
-        },
-        [](const auto& tuple)
-        {
-            for_each_tuple(tuple, [](const auto& x)
-            {
-                std::cout << x << std::endl;
-            });
-        }
-    );
+        });
+    }
+);
+```
 
 So now we can call `print` with a tuple:
 
-    print(std::make_tuple(1, 2, 3));
+```cpp
+print(std::make_tuple(1, 2, 3));
+```
 
 And it will print out:
 
-    1
-    2
-    3
+```cpp
+1
+2
+3
+```
 
 Recursive
 ---------
@@ -134,69 +159,84 @@ Even though this will print for ranges and tuples, if we were to nest a range in
 
 So now we add an additional arguments called `self` which is the `print` function itself. This extra argument is called by the [`fix`](/include/boost/hof/fix) adaptor, and so the user would still call this function with a single argument:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = fix(first_of(
-        [](auto, const auto& x) -> decltype(std::cout << x, void())
-        {
-            std::cout << x << std::endl;
-        },
-        [](auto self, const auto& range) -> decltype(self(*adl::adl_begin(range)), void())
-        {
-            for(const auto& x:range) self(x);
-        },
-        [](auto self, const auto& tuple)
-        {
-            return for_each_tuple(tuple, self);
-        }
-    ));
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = fix(first_of(
+    [](auto, const auto& x) -> decltype(std::cout << x, void())
+    {
+        std::cout << x << std::endl;
+    },
+    [](auto self, const auto& range) -> decltype(self(*adl::adl_begin(range)), void())
+    {
+        for(const auto& x:range) self(x);
+    },
+    [](auto self, const auto& tuple)
+    {
+        return for_each_tuple(tuple, self);
+    }
+));
+```
 
 This will let us print nested structures:
 
-    std::vector<int> v = { 1, 2, 3, 4 };
-    auto t = std::make_tuple(1, 2, 3, 4);
-    auto m = std::make_tuple(3, v, t);
-    print(m);
+```cpp
+std::vector<int> v = { 1, 2, 3, 4 };
+auto t = std::make_tuple(1, 2, 3, 4);
+auto m = std::make_tuple(3, v, t);
+print(m);
+```
 
 Which outputs this:
 
-    3
-    1
-    2
-    3
-    4
-    1
-    2
-    3
-    4 
+```cpp
+3
+1
+2
+3
+4
+1
+2
+3
+4
+```
 
 Variadic
 --------
 
 We can also make this `print` function variadic, so it prints every argument passed into it. We can use the [`proj`](/include/boost/hof/by) adaptor, which already calls the function on every argument passed in. First, we just rename our original `print` function to `simple_print`:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(simple_print) = fix(first_of(
-        [](auto, const auto& x) -> decltype(std::cout << x, void())
-        {
-            std::cout << x << std::endl;
-        },
-        [](auto self, const auto& range) -> decltype(self(*adl::adl_begin(range)), void())
-        {
-            for(const auto& x:range) self(x);
-        },
-        [](auto self, const auto& tuple)
-        {
-            return for_each_tuple(tuple, self);
-        }
-    ));
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(simple_print) = fix(first_of(
+    [](auto, const auto& x) -> decltype(std::cout << x, void())
+    {
+        std::cout << x << std::endl;
+    },
+    [](auto self, const auto& range) -> decltype(self(*adl::adl_begin(range)), void())
+    {
+        for(const auto& x:range) self(x);
+    },
+    [](auto self, const auto& tuple)
+    {
+        return for_each_tuple(tuple, self);
+    }
+));
+```
 
 And then apply the [`proj`](/include/boost/hof/by) adaptor to `simple_print`:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = proj(simple_print);
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(print) = proj(simple_print);
+```
 
 Now we can call `print` with several arguments:
 
-    print(5, "Hello world");
+```cpp
+print(5, "Hello world");
+```
 
 Which outputs:
 
-    5
-    Hello world
+```cpp
+5
+Hello world
+```
+

--- a/doc/src/gettingstarted.md
+++ b/doc/src/gettingstarted.md
@@ -13,56 +13,62 @@ A core part of this library is higher-order functions. A higher-order function i
 
 One way to refer to a function is to use a function pointer(or a member function pointer). So if we had our own custom `sum` function, we could pass it directly to `std::accumulate`:
 
-    int sum(int x, int y)
-    {
-        return x + y;
-    }
-    // Pass sum to accumulate
-    std::vector<int> v = { 1, 2, 3 };
-    int total = std::accumulate(v.begin(), v.end(), 0, &sum);
-
+```cpp
+int sum(int x, int y)
+{
+    return x + y;
+}
+// Pass sum to accumulate
+std::vector<int> v = { 1, 2, 3 };
+int total = std::accumulate(v.begin(), v.end(), 0, &sum);
+```
 
 However, a function pointer can only refer to one function in an overload set of functions, and it requires explicit casting to select that overload. 
 
 For example, if we had a templated `sum` function that we want to pass to `std::accumulate`, we would need an explicit cast:
 
-    template<class T, class U>
-    auto sum(T x, U y)
-    {
-        return x + y;
-    }
+```cpp
+template<class T, class U>
+auto sum(T x, U y)
+{
+    return x + y;
+}
 
-    auto sum_int = (int (*)(int, int))&sum;
-    // Call integer overload
-    int i = sum_int(1, 2);
-    // Or pass to an algorithm
-    std::vector<int> v = { 1, 2, 3 };
-    int total = std::accumulate(v.begin(), v.end(), 0, sum_int);
-
+auto sum_int = (int (*)(int, int))&sum;
+// Call integer overload
+int i = sum_int(1, 2);
+// Or pass to an algorithm
+std::vector<int> v = { 1, 2, 3 };
+int total = std::accumulate(v.begin(), v.end(), 0, sum_int);
+```
 
 Function Objects
 ----------------
 
 A function object allows the ability to encapsulate an entire overload set into one object. This can be done by defining a class that overrides the call operator like this:
 
-    // A sum function object
-    struct sum_f
+```cpp
+// A sum function object
+struct sum_f
+{
+    template<class T, class U>
+    auto operator()(T x, U y) const
     {
-        template<class T, class U>
-        auto operator()(T x, U y) const
-        {
-            return x + y;
-        }
-    };
+        return x + y;
+    }
+};
+```
 
 There are few things to note about this. First, the call operator member function is always declared `const`, which is generally required to be used with Boost.HigherOrderFunctions.(Note: The [`mutable_`](/include/boost/hof/mutable) adaptor can be used to make a mutable function object have a `const` call operator, but this should generally be avoided). Secondly, the `sum_f` class must be constructed first before it can be called:
 
-    auto sum = sum_f();
-    // Call sum function
-    auto three = sum(1, 2);
-    // Or pass to an algorithm
-    std::vector<int> v = { 1, 2, 3 };
-    int total = std::accumulate(v.begin(), v.end(), 0, sum);
+```cpp
+auto sum = sum_f();
+// Call sum function
+auto three = sum(1, 2);
+// Or pass to an algorithm
+std::vector<int> v = { 1, 2, 3 };
+int total = std::accumulate(v.begin(), v.end(), 0, sum);
+```
 
 Because the function is templated, it can be called on any type that has the plus `+` operator, not just integers. Futhermore, the `sum` variable can be used to refer to the entire overload set.
 
@@ -71,15 +77,17 @@ Lifting functions
 
 Another alternative to defining a function object, is to lift the templated function using [`BOOST_HOF_LIFT`](/include/boost/hof/lift). This will turn the entire overload set into one object like a function object:
 
-    template<class T, class U>
-    auto sum(T x, U y)
-    {
-        return x + y;
-    }
+```cpp
+template<class T, class U>
+auto sum(T x, U y)
+{
+    return x + y;
+}
 
-    // Pass sum to an algorithm
-    std::vector<int> v = { 1, 2, 3 };
-    int total = std::accumulate(v.begin(), v.end(), 0, BOOST_HOF_LIFT(sum));
+// Pass sum to an algorithm
+std::vector<int> v = { 1, 2, 3 };
+int total = std::accumulate(v.begin(), v.end(), 0, BOOST_HOF_LIFT(sum));
+```
 
 However, due to limitations in C++14 this will not preserve `constexpr`. In those cases, its better to use a function object.
 
@@ -88,11 +96,15 @@ Declaring functions
 
 Now, this is useful for local functions. However, many times we want to write functions and make them available for others to use. Boost.HigherOrderFunctions provides [`BOOST_HOF_STATIC_FUNCTION`](/include/boost/hof/function) to declare the function object at the global or namespace scope:
 
-    BOOST_HOF_STATIC_FUNCTION(sum) = sum_f();
+```cpp
+BOOST_HOF_STATIC_FUNCTION(sum) = sum_f();
+```
 
 The [`BOOST_HOF_STATIC_FUNCTION`](/include/boost/hof/function) declares a global variable following the best practices as outlined in [N4381](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html). This includes using `const` to avoid global state, compile-time initialization of the function object to avoid the [static initialization order fiasco](https://isocpp.org/wiki/faq/ctors#static-init-order), and an external address of the function object that is the same across translation units to avoid possible One-Definition-Rule(ODR) violations. In C++17, this can be achieved using an `inline` variable:
 
-    inline const constexpr auto sum = sum_f{};
+```cpp
+inline const constexpr auto sum = sum_f{};
+```
 
 The [`BOOST_HOF_STATIC_FUNCTION`](/include/boost/hof/function) macro provides a portable way to do this that supports pre-C++17 compilers and MSVC.
 
@@ -101,49 +113,67 @@ Adaptors
 
 Now we have defined the function as a function object, we can add new "enhancements" to the function. One enhancement is to write "extension" methods. The proposal [N4165](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4165.pdf) for Unified Call Syntax(UFCS) would have allowed a function call of `x.f(y)` to become `f(x, y)`. Without UFCS in C++, we can instead use pipable function which would transform `x | f(y)` into `f(x, y)`. To make `sum_f` function pipable using the [`pipable`](/include/boost/hof/pipable) adaptor, we can simply write:
 
-    BOOST_HOF_STATIC_FUNCTION(sum) = pipable(sum_f());
+```cpp
+BOOST_HOF_STATIC_FUNCTION(sum) = pipable(sum_f());
+```
 
 Then the parameters can be piped into it, like this:
 
-    auto three = 1 | sum(2);
+```cpp
+auto three = 1 | sum(2);
+```
 
 Pipable function can be chained mutliple times just like the `.` operator:
 
-    auto four = 1 | sum(2) | sum(1);
+```cpp
+auto four = 1 | sum(2) | sum(1);
+```
 
 Alternatively, instead of using the `|` operator, pipable functions can be chained together using the [`flow`](/include/boost/hof/flow) adaptor:
 
-    auto four = flow(sum(2), sum(1))(1); 
+```cpp
+auto four = flow(sum(2), sum(1))(1);
+```
 
 Another enhancement that can be done to functions is defining named infix operators using the [`infix`](/include/boost/hof/infix) adaptor:
 
-    BOOST_HOF_STATIC_FUNCTION(sum) = infix(sum_f());
+```cpp
+BOOST_HOF_STATIC_FUNCTION(sum) = infix(sum_f());
+```
 
 And it could be called like this:
 
-    auto three = 1 <sum> 2;
+```cpp
+auto three = 1 <sum> 2;
+```
 
 In addition, adaptors are provided that support simple functional operations such as [partial application](https://en.wikipedia.org/wiki/Partial_application) and [function composition](https://en.wikipedia.org/wiki/Function_composition):
 
-    auto add_1 = partial(sum)(1);
-    auto add_2 = compose(add_1, add_1);
-    auto three = add_2(1);
+```cpp
+auto add_1 = partial(sum)(1);
+auto add_2 = compose(add_1, add_1);
+auto three = add_2(1);
+```
 
 Lambdas
 -------
 
 Writing function objects can be a little verbose. C++ provides lambdas which have a much terser syntax for defining functions. Of course, lambdas can work with all the adaptors in the library, however, if we want to declare a function using lambdas, [`BOOST_HOF_STATIC_FUNCTION`](/include/boost/hof/function) won't work. Instead, [`BOOST_HOF_STATIC_LAMBDA_FUNCTION`](BOOST_HOF_STATIC_LAMBDA_FUNCTION) can be used to the declare the lambda as a function instead, this will initialize the function at compile-time and avoid possible ODR violations:
 
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(sum) = [](auto x, auto y)
-    {
-        return x + y;
-    };
+```cpp
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(sum) = [](auto x, auto y)
+{
+    return x + y;
+};
+```
 
 Additionally, adaptors can be used, so the pipable version of `sum` can be written like this:
 
-    // Pipable sum
-    BOOST_HOF_STATIC_LAMBDA_FUNCTION(sum) = pipable([](auto x, auto y)
-    {
-        return x + y;
-    });
+```cpp
+// Pipable sum
+BOOST_HOF_STATIC_LAMBDA_FUNCTION(sum) = pipable([](auto x, auto y)
+{
+    return x + y;
+});
+```
 

--- a/doc/src/more_examples.md
+++ b/doc/src/more_examples.md
@@ -33,16 +33,20 @@ Projections
 
 Instead of writing the projection multiple times in algorithms:
 
-    std::sort(std::begin(people), std::end(people),
-              [](const Person& a, const Person& b) {
-                return a.year_of_birth < b.year_of_birth;
-              });
+```cpp
+std::sort(std::begin(people), std::end(people),
+          [](const Person& a, const Person& b) {
+            return a.year_of_birth < b.year_of_birth;
+          });
+```
 
 We can use the [`proj`](/include/boost/hof/by) adaptor to project `year_of_birth` on the comparison
 operator:
 
-    std::sort(std::begin(people), std::end(people),
-            proj(&Person::year_of_birth, _ < _));
+```cpp
+std::sort(std::begin(people), std::end(people),
+        proj(&Person::year_of_birth, _ < _));
+```
 
 Ordering evaluation of arguments
 --------------------------------
@@ -51,7 +55,9 @@ When we write `f(foo(), bar())`, the standard does not guarantee the order in
 which the `foo()` and `bar()` arguments are evaluated. So with `apply_eval` we
 can order them from left-to-right:
 
-    apply_eval(f, [&]{ return foo(); }, [&]{ return bar(); });
+```cpp
+apply_eval(f, [&]{ return foo(); }, [&]{ return bar(); });
+```
 
 Extension methods
 -----------------
@@ -59,36 +65,44 @@ Extension methods
 Chaining many functions together, like what is done for range based libraries,
 can make things hard to read:
 
-    auto r = transform(
-        filter(
-            numbers,
-            [](int x) { return x > 2; }
-        ),
-        [](int x) { return x * x; }
-    );
+```cpp
+auto r = transform(
+    filter(
+        numbers,
+        [](int x) { return x > 2; }
+    ),
+    [](int x) { return x * x; }
+);
+```
 
 It would be nice to write this:
 
-    auto r = numbers
-        .filter([](int x) { return x > 2; })
-        .transform([](int x) { return x * x; });
+```cpp
+auto r = numbers
+    .filter([](int x) { return x > 2; })
+    .transform([](int x) { return x * x; });
+```
 
 The proposal [N4165](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4165.pdf) 
 for Unified Call Syntax(UFCS) would have allowed a function call of `x.f(y)` to become
 `f(x, y)`. However, this was rejected by the comittee. So instead pipable functions can be
 used to achieve extension methods. So it can be written like this:
 
-    auto r = numbers
-        | filter([](int x) { return x > 2; })
-        | transform([](int x) { return x * x; });
+```cpp
+auto r = numbers
+    | filter([](int x) { return x > 2; })
+    | transform([](int x) { return x * x; });
+```
 
 Now, if some users feel a little worried about overloading the _bitwise or_
 operator, pipable functions can also be used with [`flow`](/include/boost/hof/flow) like this:
 
-    auto r = flow(
-        filter([](int x) { return x > 2; }),
-        transform([](int x) { return x * x; })
-    )(numbers);
+```cpp
+auto r = flow(
+    filter([](int x) { return x > 2; }),
+    transform([](int x) { return x * x; })
+)(numbers);
+```
 
 No fancy or confusing operating overloading and everything is still quite
 readable.

--- a/doc/src/partialfunctions.md
+++ b/doc/src/partialfunctions.md
@@ -8,39 +8,51 @@ Partial function evaluation
 
 Many of the adaptors(such as [partial](partial) or [pipable](pipable)) in the library supports optional partial evaluation of functions. For example, if we have the `sum` function adapted with the `partial` adaptor:
 
-    auto sum = partial([](int x, int y)
-    {
-        return x+y;
-    });
+```cpp
+auto sum = partial([](int x, int y)
+{
+    return x+y;
+});
+```
 
 So if we write `sum(1, 2)` it will return 3, however, if we write `sum(1)` it will return a new function, which when called again, it will evaluate the function and return 3:
 
-    int i = sum(1, 2); // Returns 3
-    auto f = sum(1);
-    int j = f(2); // returns 3
+```cpp
+int i = sum(1, 2); // Returns 3
+auto f = sum(1);
+int j = f(2); // returns 3
+```
 
 Of course due to limitations in C++, deciding whether evaluate the function or to partially evaluated it, is based on the callability of the function and not arity. So if we call `sum(1, 2, 3)`, it will return a function:
 
-    auto f = sum(1, 2, 3);
+```cpp
+auto f = sum(1, 2, 3);
+```
 
 However, this can get out of hande as the function `f` will never be evaluated. Plus, it would be nice to produce an error at the point of calling the function rather than a confusing error of trying to use a partial function. The [limit](limit) decorator lets us annotate the function with the max arity:
 
-    auto sum = partial(limit_c<2>([](int x, int y)
-    {
-        return x+y;
-    }));
+```cpp
+auto sum = partial(limit_c<2>([](int x, int y)
+{
+    return x+y;
+}));
+```
 
 So now if we call `sum(1, 2, 3)`, we will get a compiler error. So this improves the situation, but it is not without its limitations. For example if we were to define a triple sum using the [pipable](pipable) adaptor:
 
-    auto sum = pipable(limit_c<3>([](int x, int y, int z)
-    {
-        return x+y+z;
-    }));
+```cpp
+auto sum = pipable(limit_c<3>([](int x, int y, int z)
+{
+    return x+y+z;
+}));
+```
 
 So if we call `sum(1)`, there is no compiler error, not until we try to pipe in a value:
 
-    auto f = sum(1); // No error here
-    auto i = 2 | f; // Compile error
+```cpp
+auto f = sum(1); // No error here
+auto i = 2 | f; // Compile error
+```
 
 Of course, the goal may not be to use the pipable call, which could lead to some confusing errors. Currently, there is not a good solution to this.
 

--- a/doc/src/point_free.md
+++ b/doc/src/point_free.md
@@ -13,51 +13,69 @@ Variadic print
 
 For example, if we want to write a variadic print function that prints each argument, like this:
 
-    print("Hello", "World");
+```cpp
+print("Hello", "World");
+```
 
 We would write something like the following, which would recursively iterate over the arguments using varidiac templates:
 
-    // Base case
-    void print()
-    {}
+```cpp
+// Base case
+void print()
+{}
 
-    template<class T, class... Ts>
-    void print(const T& x, const Ts&... xs)
-    {
-        std::cout << x;
-        print(xs...);
-    }
+template<class T, class... Ts>
+void print(const T& x, const Ts&... xs)
+{
+    std::cout << x;
+    print(xs...);
+}
+```
 
 Instead with point-free style, we can write this using the [`proj`](/include/boost/hof/by) adaptor, which calls a function on each arguments. Of course, `std::cout` is not a function, but we can make it one by using `BOOST_HOF_LIFT`:
 
-    BOOST_HOF_STATIC_FUNCTION(simple_print) = BOOST_HOF_LIFT(std::ref(std::cout) << _);
+```cpp
+BOOST_HOF_STATIC_FUNCTION(simple_print) = BOOST_HOF_LIFT(std::ref(std::cout) << _);
+```
 
 This uses the [placeholders](/include/boost/hof/placeholders) to create a function that prints to `std::cout`. Then we can pass `simple_print` to the [`proj`](/include/boost/hof/by) adaptor:
 
-    BOOST_HOF_STATIC_FUNCTION(print) = proj(simple_print);
+```cpp
+BOOST_HOF_STATIC_FUNCTION(print) = proj(simple_print);
+```
 
 As the [`proj`](/include/boost/hof/by) adaptor calls the function for each argument passed in, `b(f)(x, y)` is the equivalent of calling `f(x)` and then `f(y)`. In this case, it will call `simple_print(x)` and then `simple_print(y)`:
 
-    print("Hello", "World");
+```cpp
+print("Hello", "World");
+```
 
 Which prints out:
 
-    HelloWorld
+```cpp
+HelloWorld
+```
 
 Of course, this puts all the output together, but we can further extend this to print a new line for each item by composing it:
 
-    BOOST_HOF_STATIC_FUNCTION(print_lines) = proj(flow(simple_print, _ << std::integral_constant<char, '\n'>{}));
+```cpp
+BOOST_HOF_STATIC_FUNCTION(print_lines) = proj(flow(simple_print, _ << std::integral_constant<char, '\n'>{}));
+```
 
 The [flow](/include/boost/hof/flow) adaptor does function composition but the functions are called from left-to-right. That is `flow(f, g)(x)` is equivalent to `g(f(x))`. So in this case, it will call `simple_print` on the argument which returns `std::cout` and then pass that to the next function which calls the stream with the newline character. In the above, we write `std::integral_constant<char, '\n'>{}` instead of just `'\n'` because the function is statically defined, so all values must be defined statically.
 
 So now calling `print_lines`:
 
-    print_lines("Hello", "World");
+```cpp
+print_lines("Hello", "World");
+```
 
 It will print out:
 
-    Hello
-    World
+```cpp
+Hello
+World
+```
 
 With each argument on its own line.
 
@@ -66,27 +84,33 @@ Variadic sum
 
 Another example, say we would like to write a varidiac version of `max`. We could implement it like this:
 
-    // Base case
-    template<class T>
-    T max(const T& x)
-    {
-        return x;
-    }
+```cpp
+// Base case
+template<class T>
+T max(const T& x)
+{
+    return x;
+}
 
-    template<class T, class... Ts>
-    T max(const T& x, const T& y, const Ts&... xs)
-    {
-        return std::max(x, max(y, xs...));
-    }
+template<class T, class... Ts>
+T max(const T& x, const T& y, const Ts&... xs)
+{
+    return std::max(x, max(y, xs...));
+}
+```
 
 With point-free style programming, we can recognize this is a [fold](https://en.wikipedia.org/wiki/Fold_%28higher-order_function%29), and write it using the [`fold`](/include/boost/hof/fold) adaptor, which will do a fold over the variadic parameters:
 
-    BOOST_HOF_STATIC_FUNCTION(max) = fold(BOOST_HOF_LIFT(std::max));
+```cpp
+BOOST_HOF_STATIC_FUNCTION(max) = fold(BOOST_HOF_LIFT(std::max));
+```
 
 [`BOOST_HOF_LIFT`](/include/boost/hof/lift) is used to grab the entire overload set of `std::max` function, which is needed since `std::max` is templated and we want the variadic `std::max` function to handle any types as well. So now it can be called like this:
 
-    auto n = max(1, 2, 4, 3); // Returns 4
-    auto m = max(0.1, 0.2, 0.5, 0.4); // Returns 0.5
+```cpp
+auto n = max(1, 2, 4, 3); // Returns 4
+auto m = max(0.1, 0.2, 0.5, 0.4); // Returns 0.5
+```
 
 By using [`fold`](/include/boost/hof/fold), `max(1, 2, 4, 3)` will call `std::max` like `std::max(std::max(std::max(1, 2), 4), 3)` and `max(0.1, 0.2, 0.5, 0.4)` will be called like `std::max(std::max(std::max(0.1, 0.2), 0.5), 0.4)`.
 

--- a/include/boost/hof/alias.hpp
+++ b/include/boost/hof/alias.hpp
@@ -29,29 +29,31 @@
 /// Synopsis
 /// --------
 /// 
-///     // Alias the type using a member variable
-///     template<class T, class Tag=void>
-///     class alias;
+/// ```cpp
+/// // Alias the type using a member variable
+/// template<class T, class Tag=void>
+/// class alias;
 /// 
-///     // Alias the type by inheriting
-///     template<class T, class Tag=void>
-///     class alias_inherit;
+/// // Alias the type by inheriting
+/// template<class T, class Tag=void>
+/// class alias_inherit;
 /// 
-///     // Alias the type using a static variable
-///     template<class T, class Tag=void>
-///     class alias_static;
+/// // Alias the type using a static variable
+/// template<class T, class Tag=void>
+/// class alias_static;
 /// 
-///     // Retrieve tag from alias
-///     template<class Alias>
-///     class alias_tag;
+/// // Retrieve tag from alias
+/// template<class Alias>
+/// class alias_tag;
 /// 
-///     // Check if type has a certian tag
-///     template<class T, class Tag>
-///     class has_tag;
+/// // Check if type has a certian tag
+/// template<class T, class Tag>
+/// class has_tag;
 /// 
-///     // Retrieve value from alias
-///     template<class Alias>
-///     constexpr auto alias_value(Alias&&);
+/// // Retrieve value from alias
+/// template<class Alias>
+/// constexpr auto alias_value(Alias&&);
+/// ```
 /// 
 
 #ifdef _MSC_VER

--- a/include/boost/hof/always.hpp
+++ b/include/boost/hof/always.hpp
@@ -28,17 +28,20 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class T>
-///     constexpr auto always(T value);
+/// ```cpp
+/// template<class T>
+/// constexpr auto always(T value);
 /// 
-///     template<class T>
-///     constexpr auto always(void);
-/// 
+/// template<class T>
+/// constexpr auto always(void);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(always(x)(xs...) == x);
+/// ```cpp
+/// assert(always(x)(xs...) == x);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -50,24 +53,25 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <algorithm>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <algorithm>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     int main() {
-///         int ten = 10;
-///         assert( always(ten)(1,2,3,4,5) == 10 );
-///     }
+/// int main() {
+///     int ten = 10;
+///     assert( always(ten)(1,2,3,4,5) == 10 );
+/// }
 /// 
-///     // Count all
-///     template<class Iterator, class T>
-///     auto count(Iterator first, Iterator last)
-///     {
-///         return std::count_if(first, last, always(true));
-///     }
+/// // Count all
+/// template<class Iterator, class T>
+/// auto count(Iterator first, Iterator last)
+/// {
+///     return std::count_if(first, last, always(true));
+/// }
+/// ```
 /// 
-
 
 #ifndef BOOST_HOF_NO_CONSTEXPR_VOID
 #if defined(__clang__) && BOOST_HOF_HAS_RELAXED_CONSTEXPR

--- a/include/boost/hof/apply.hpp
+++ b/include/boost/hof/apply.hpp
@@ -19,14 +19,18 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F, class... Ts>
-///     constexpr auto apply(F&& f, Ts&&... xs);
+/// ```cpp
+/// template<class F, class... Ts>
+/// constexpr auto apply(F&& f, Ts&&... xs);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(apply(f)(xs...) == f(xs...));
-///     assert(fold(apply, f)(x, y, z) == f(x)(y)(z));
+/// ```cpp
+/// assert(apply(f)(xs...) == f(xs...));
+/// assert(fold(apply, f)(x, y, z) == f(x)(y)(z));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -38,21 +42,23 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct sum_f
+/// struct sum_f
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         assert(boost::hof::apply(sum_f(), 1, 2) == 3);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     assert(boost::hof::apply(sum_f(), 1, 2) == 3);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/result_of.hpp>

--- a/include/boost/hof/apply_eval.hpp
+++ b/include/boost/hof/apply_eval.hpp
@@ -21,13 +21,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F, class... Ts>
-///     constexpr auto apply_eval(F&& f, Ts&&... xs);
+/// ```cpp
+/// template<class F, class... Ts>
+/// constexpr auto apply_eval(F&& f, Ts&&... xs);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(apply_eval(f)(xs...) == f(eval(xs)...));
+/// ```cpp
+/// assert(apply_eval(f)(xs...) == f(eval(xs)...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -43,21 +47,23 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct sum_f
+/// struct sum_f
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         assert(boost::hof::apply_eval(sum_f(), []{ return 1; }, []{ return 2; }) == 3);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     assert(boost::hof::apply_eval(sum_f(), []{ return 1; }, []{ return 2; }) == 3);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/config.hpp>

--- a/include/boost/hof/arg.hpp
+++ b/include/boost/hof/arg.hpp
@@ -26,23 +26,26 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class IntegralConstant>
-///     constexpr auto arg(IntegralConstant);
+/// ```cpp
+/// template<class IntegralConstant>
+/// constexpr auto arg(IntegralConstant);
 /// 
-///     template<std::size_t N, class... Ts>
-///     constexpr auto arg_c(Ts&&...);
-/// 
+/// template<std::size_t N, class... Ts>
+/// constexpr auto arg_c(Ts&&...);
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     int main() {
-///         assert(arg(std::integral_constant<int, 3>())(1,2,3,4,5) == 3);
-///     }
+/// int main() {
+///     assert(arg(std::integral_constant<int, 3>())(1,2,3,4,5) == 3);
+/// }
+/// ```
 /// 
 
 namespace boost { namespace hof {

--- a/include/boost/hof/capture.hpp
+++ b/include/boost/hof/capture.hpp
@@ -31,43 +31,48 @@
 /// Synopsis
 /// --------
 /// 
-///     // Capture by decaying each value
-///     template<class... Ts>
-///     constexpr auto capture(Ts&&... xs);
+/// ```cpp
+/// // Capture by decaying each value
+/// template<class... Ts>
+/// constexpr auto capture(Ts&&... xs);
 /// 
-///     // Capture lvalues by reference and rvalue reference by reference
-///     template<class... Ts>
-///     constexpr auto capture_forward(Ts&&... xs);
+/// // Capture lvalues by reference and rvalue reference by reference
+/// template<class... Ts>
+/// constexpr auto capture_forward(Ts&&... xs);
 /// 
-///     // Capture lvalues by reference and rvalues by value.
-///     template<class... Ts>
-///     constexpr auto capture_basic(Ts&&... xs);
+/// // Capture lvalues by reference and rvalues by value.
+/// template<class... Ts>
+/// constexpr auto capture_basic(Ts&&... xs);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(capture(xs...)(f)(ys...) == f(xs..., ys...));
-/// 
+/// ```cpp
+/// assert(capture(xs...)(f)(ys...) == f(xs..., ys...));
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct sum_f
+/// struct sum_f
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         auto add_one = boost::hof::capture(1)(sum_f());
-///         assert(add_one(2) == 3);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     auto add_one = boost::hof::capture(1)(sum_f());
+///     assert(add_one(2) == 3);
+/// }
+/// ```
 /// 
 
 namespace boost { namespace hof {

--- a/include/boost/hof/combine.hpp
+++ b/include/boost/hof/combine.hpp
@@ -21,13 +21,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F, class... Gs>
-///     constexpr combine_adaptor<F, Gs...> combine(F f, Gs... gs);
+/// ```cpp
+/// template<class F, class... Gs>
+/// constexpr combine_adaptor<F, Gs...> combine(F f, Gs... gs);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(combine(f, gs...)(xs...) == f(gs(xs)...));
+/// ```cpp
+/// assert(combine(f, gs...)(xs...) == f(gs(xs)...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -40,18 +44,20 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     #include <tuple>
-///     #include <utility>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// #include <tuple>
+/// #include <utility>
 /// 
-///     int main() {
-///         auto f = boost::hof::combine(
-///             boost::hof::construct<std::tuple>(),
-///             boost::hof::capture(1)(boost::hof::construct<std::pair>()),
-///             boost::hof::capture(2)(boost::hof::construct<std::pair>()));
-///         assert(f(3, 7) == std::make_tuple(std::make_pair(1, 3), std::make_pair(2, 7)));
-///     }
+/// int main() {
+///     auto f = boost::hof::combine(
+///         boost::hof::construct<std::tuple>(),
+///         boost::hof::capture(1)(boost::hof::construct<std::pair>()),
+///         boost::hof::capture(2)(boost::hof::construct<std::pair>()));
+///     assert(f(3, 7) == std::make_tuple(std::make_pair(1, 3), std::make_pair(2, 7)));
+/// }
+/// ```
 /// 
 
 #include <boost/hof/pack.hpp>

--- a/include/boost/hof/compose.hpp
+++ b/include/boost/hof/compose.hpp
@@ -23,13 +23,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class... Fs>
-///     constexpr compose_adaptor<Fs...> compose(Fs... fs);
+/// ```cpp
+/// template<class... Fs>
+/// constexpr compose_adaptor<Fs...> compose(Fs... fs);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(compose(f, g)(xs...) == f(g(xs...)));
+/// ```cpp
+/// assert(compose(f, g)(xs...) == f(g(xs...)));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -42,38 +46,39 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct increment
+/// struct increment
+/// {
+///     template<class T>
+///     T operator()(T x) const
 ///     {
-///         template<class T>
-///         T operator()(T x) const
-///         {
-///             return x + 1;
-///         }
-///     };
-/// 
-///     struct decrement
-///     {
-///         template<class T>
-///         T operator()(T x) const
-///         {
-///             return x - 1;
-///         }
-///     };
-/// 
-///     int main() {
-///         int r = compose(increment(), decrement(), increment())(3);
-///         assert(r == 4);
+///         return x + 1;
 ///     }
+/// };
+/// 
+/// struct decrement
+/// {
+///     template<class T>
+///     T operator()(T x) const
+///     {
+///         return x - 1;
+///     }
+/// };
+/// 
+/// int main() {
+///     int r = compose(increment(), decrement(), increment())(3);
+///     assert(r == 4);
+/// }
+/// ```
 /// 
 /// References
 /// ----------
 /// 
 /// * [Function composition](https://en.wikipedia.org/wiki/Function_composition)
-/// 
 /// 
 
 #include <boost/hof/detail/callable_base.hpp>

--- a/include/boost/hof/construct.hpp
+++ b/include/boost/hof/construct.hpp
@@ -22,41 +22,45 @@
 /// Synopsis
 /// --------
 /// 
-///     // Construct by decaying each value
-///     template<class T>
-///     constexpr auto construct();
+/// ```cpp
+/// // Construct by decaying each value
+/// template<class T>
+/// constexpr auto construct();
 /// 
-///     template<template<class...> class Template>
-///     constexpr auto construct();
+/// template<template<class...> class Template>
+/// constexpr auto construct();
 /// 
-///     // Construct by deducing lvalues by reference and rvalue reference by reference
-///     template<class T>
-///     constexpr auto construct_forward();
+/// // Construct by deducing lvalues by reference and rvalue reference by reference
+/// template<class T>
+/// constexpr auto construct_forward();
 /// 
-///     template<template<class...> class Template>
-///     constexpr auto construct_forward();
+/// template<template<class...> class Template>
+/// constexpr auto construct_forward();
 /// 
-///     // Construct by deducing lvalues by reference and rvalues by value.
-///     template<class T>
-///     constexpr auto construct_basic();
+/// // Construct by deducing lvalues by reference and rvalues by value.
+/// template<class T>
+/// constexpr auto construct_basic();
 /// 
-///     template<template<class...> class Template>
-///     constexpr auto construct_basic();
+/// template<template<class...> class Template>
+/// constexpr auto construct_basic();
 /// 
-///     // Construct by deducing the object from a metafunction
-///     template<class MetafunctionClass>
-///     constexpr auto construct_meta();
+/// // Construct by deducing the object from a metafunction
+/// template<class MetafunctionClass>
+/// constexpr auto construct_meta();
 /// 
-///     template<template<class...> class MetafunctionTemplate>
-///     constexpr auto construct_meta();
+/// template<template<class...> class MetafunctionTemplate>
+/// constexpr auto construct_meta();
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(construct<T>()(xs...) == T(xs...));
-///     assert(construct<Template>()(xs...) == Template<decltype(xs)...>(xs...));
-///     assert(construct_meta<MetafunctionClass>()(xs...) == MetafunctionClass::apply<decltype(xs)...>(xs...));
-///     assert(construct_meta<MetafunctionTemplate>()(xs...) == MetafunctionTemplate<decltype(xs)...>::type(xs...));
+/// ```cpp
+/// assert(construct<T>()(xs...) == T(xs...));
+/// assert(construct<Template>()(xs...) == Template<decltype(xs)...>(xs...));
+/// assert(construct_meta<MetafunctionClass>()(xs...) == MetafunctionClass::apply<decltype(xs)...>(xs...));
+/// assert(construct_meta<MetafunctionTemplate>()(xs...) == MetafunctionTemplate<decltype(xs)...>::type(xs...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -77,14 +81,16 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     #include <vector>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// #include <vector>
 /// 
-///     int main() {
-///         auto v = boost::hof::construct<std::vector<int>>()(5, 5);
-///         assert(v.size() == 5);
-///     }
+/// int main() {
+///     auto v = boost::hof::construct<std::vector<int>>()(5, 5);
+///     assert(v.size() == 5);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/forward.hpp>

--- a/include/boost/hof/decay.hpp
+++ b/include/boost/hof/decay.hpp
@@ -19,14 +19,16 @@
 /// Synopsis
 /// --------
 /// 
-///     struct
+/// ```cpp
+/// struct
+/// {
+///     template<class T>
+///     constexpr typename decay<T>::type operator()(T&& x) const
 ///     {
-///         template<class T>
-///         constexpr typename decay<T>::type operator()(T&& x) const
-///         {
-///             return boost::hof::forward<T>(x);
-///         }
-///     } decay;
+///         return boost::hof::forward<T>(x);
+///     }
+/// } decay;
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/decorate.hpp
+++ b/include/boost/hof/decorate.hpp
@@ -25,13 +25,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr decorate_adaptor<F> decorate(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr decorate_adaptor<F> decorate(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(decorate(f)(x)(g)(xs...) == f(x, g, xs...));
+/// ```cpp
+/// assert(decorate(f)(x)(g)(xs...) == f(x, g, xs...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -44,41 +48,43 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     #include <iostream>
-///     #include <string>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// #include <iostream>
+/// #include <string>
+/// using namespace boost::hof;
 /// 
-///     struct logger_f
+/// struct logger_f
+/// {
+///     template<class F, class... Ts>
+///     auto operator()(const std::string& message, F&& f, Ts&&... xs) const 
+///         -> decltype(f(std::forward<Ts>(xs)...))
 ///     {
-///         template<class F, class... Ts>
-///         auto operator()(const std::string& message, F&& f, Ts&&... xs) const 
-///             -> decltype(f(std::forward<Ts>(xs)...))
-///         {
-///             // Message to print out when the function is called
-///             std::cout << message << std::endl;
-///             // Call the function
-///             return f(std::forward<Ts>(xs)...);
-///         }
-///     };
-///     // The logger decorator
-///     BOOST_HOF_STATIC_FUNCTION(logger) = boost::hof::decorate(logger_f());
-///     
-///     struct sum_f
-///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-///     
-///     BOOST_HOF_STATIC_FUNCTION(sum) = sum_f();
-///     int main() {
-///         // Use the logger decorator to print "Calling sum" when the function is called
-///         assert(3 == logger("Calling sum")(sum)(1, 2));
+///         // Message to print out when the function is called
+///         std::cout << message << std::endl;
+///         // Call the function
+///         return f(std::forward<Ts>(xs)...);
 ///     }
+/// };
+/// // The logger decorator
+/// BOOST_HOF_STATIC_FUNCTION(logger) = boost::hof::decorate(logger_f());
+/// 
+/// struct sum_f
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
+///     {
+///         return x+y;
+///     }
+/// };
+/// 
+/// BOOST_HOF_STATIC_FUNCTION(sum) = sum_f();
+/// int main() {
+///     // Use the logger decorator to print "Calling sum" when the function is called
+///     assert(3 == logger("Calling sum")(sum)(1, 2));
+/// }
+/// ```
 /// 
 
 #include <boost/hof/reveal.hpp>

--- a/include/boost/hof/eval.hpp
+++ b/include/boost/hof/eval.hpp
@@ -23,8 +23,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F, class... Ts>
-///     constexpr auto eval(F&& f, Ts&&...);
+/// ```cpp
+/// template<class F, class... Ts>
+/// constexpr auto eval(F&& f, Ts&&...);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -36,12 +38,14 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     int main() {
-///         assert(boost::hof::eval([]{ return 3; }) == 3);
-///     }
+/// int main() {
+///     assert(boost::hof::eval([]{ return 3; }) == 3);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/first_of.hpp
+++ b/include/boost/hof/first_of.hpp
@@ -27,8 +27,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class... Fs>
-///     constexpr first_of_adaptor<Fs...> first_of(Fs... fs);
+/// ```cpp
+/// template<class... Fs>
+/// constexpr first_of_adaptor<Fs...> first_of(Fs... fs);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -41,29 +43,31 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <iostream>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <iostream>
+/// using namespace boost::hof;
 /// 
-///     struct for_ints
+/// struct for_ints
+/// {
+///     void operator()(int) const
 ///     {
-///         void operator()(int) const
-///         {
-///             printf("Int\n");
-///         }
-///     };
-/// 
-///     struct for_floats
-///     {
-///         void operator()(float) const
-///         {
-///             printf("Float\n");
-///         }
-///     };
-/// 
-///     int main() {
-///         first_of(for_ints(), for_floats())(3.0);
+///         printf("Int\n");
 ///     }
+/// };
+/// 
+/// struct for_floats
+/// {
+///     void operator()(float) const
+///     {
+///         printf("Float\n");
+///     }
+/// };
+/// 
+/// int main() {
+///     first_of(for_ints(), for_floats())(3.0);
+/// }
+/// ```
 /// 
 /// This will print `Int` because the `for_floats` function object won't ever be
 /// called. Due to the conversion rules in C++, the `for_ints` function can be

--- a/include/boost/hof/fix.hpp
+++ b/include/boost/hof/fix.hpp
@@ -25,18 +25,24 @@
 /// recursion limits of the compiler. This can be accomplished using
 /// [`boost::hof::result`](/include/boost/hof/result):
 /// 
-///     int r = boost::hof::result<int>(factorial)(5);
+/// ```cpp
+/// int r = boost::hof::result<int>(factorial)(5);
+/// ```
 /// 
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr fix_adaptor<F> fix(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr fix_adaptor<F> fix(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(fix(f)(xs...) == f(fix(f), xs...));
+/// ```cpp
+/// assert(fix(f)(xs...) == f(fix(f), xs...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -49,18 +55,20 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     int main() {
-///         auto factorial = boost::hof::fix(
-///             [](auto recurse, auto x) -> decltype(x) { 
-///                 return x == 0 ? 1 : x * recurse(x-1); 
-///             }
-///         );
-///         int r = boost::hof::result<int>(factorial)(5);
-///         assert(r == 5*4*3*2*1);
-///     }
+/// int main() {
+///     auto factorial = boost::hof::fix(
+///         [](auto recurse, auto x) -> decltype(x) { 
+///             return x == 0 ? 1 : x * recurse(x-1); 
+///         }
+///     );
+///     int r = boost::hof::result<int>(factorial)(5);
+///     assert(r == 5*4*3*2*1);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/flip.hpp
+++ b/include/boost/hof/flip.hpp
@@ -19,13 +19,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     flip_adaptor<F> flip(F f);
+/// ```cpp
+/// template<class F>
+/// flip_adaptor<F> flip(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(flip(f)(x, y, xs...) == f(y, x, xs...));
+/// ```cpp
+/// assert(flip(f)(x, y, xs...) == f(y, x, xs...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -45,13 +49,15 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     int main() {
-///         int r = boost::hof::flip(boost::hof::_ - boost::hof::_)(2, 5);
-///         assert(r == 3);
-///     }
+/// int main() {
+///     int r = boost::hof::flip(boost::hof::_ - boost::hof::_)(2, 5);
+///     assert(r == 3);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/callable_base.hpp>

--- a/include/boost/hof/flow.hpp
+++ b/include/boost/hof/flow.hpp
@@ -23,13 +23,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class... Fs>
-///     constexpr flow_adaptor<Fs...> flow(Fs... fs);
+/// ```cpp
+/// template<class... Fs>
+/// constexpr flow_adaptor<Fs...> flow(Fs... fs);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(flow(f, g)(xs...) == g(f(xs...)));
+/// ```cpp
+/// assert(flow(f, g)(xs...) == g(f(xs...)));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -42,32 +46,34 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct increment
+/// struct increment
+/// {
+///     template<class T>
+///     T operator()(T x) const
 ///     {
-///         template<class T>
-///         T operator()(T x) const
-///         {
-///             return x + 1;
-///         }
-///     };
-/// 
-///     struct decrement
-///     {
-///         template<class T>
-///         T operator()(T x) const
-///         {
-///             return x - 1;
-///         }
-///     };
-/// 
-///     int main() {
-///         int r = flow(increment(), decrement(), increment())(3);
-///         assert(r == 4);
+///         return x + 1;
 ///     }
+/// };
+/// 
+/// struct decrement
+/// {
+///     template<class T>
+///     T operator()(T x) const
+///     {
+///         return x - 1;
+///     }
+/// };
+/// 
+/// int main() {
+///     int r = flow(increment(), decrement(), increment())(3);
+///     assert(r == 4);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/fold.hpp
+++ b/include/boost/hof/fold.hpp
@@ -26,19 +26,23 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F, class State>
-///     constexpr fold_adaptor<F, State> fold(F f, State s);
+/// ```cpp
+/// template<class F, class State>
+/// constexpr fold_adaptor<F, State> fold(F f, State s);
 /// 
-///     template<class F>
-///     constexpr fold_adaptor<F> fold(F f);
+/// template<class F>
+/// constexpr fold_adaptor<F> fold(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(fold(f, z)() == z);
-///     assert(fold(f, z)(x, xs...) == fold(f, f(z, x))(xs...));
-///     assert(fold(f)(x) == x);
-///     assert(fold(f)(x, y, xs...) == fold(f)(f(x, y), xs...));
+/// ```cpp
+/// assert(fold(f, z)() == z);
+/// assert(fold(f, z)(x, xs...) == fold(f, f(z, x))(xs...));
+/// assert(fold(f)(x) == x);
+/// assert(fold(f)(x, y, xs...) == fold(f)(f(x, y), xs...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -55,20 +59,22 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct max_f
+/// struct max_f
+/// {
+///     template<class T, class U>
+///     constexpr T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         constexpr T operator()(T x, U y) const
-///         {
-///             return x > y ? x : y;
-///         }
-///     };
-///     int main() {
-///         assert(boost::hof::fold(max_f())(2, 3, 4, 5) == 5);
+///         return x > y ? x : y;
 ///     }
+/// };
+/// int main() {
+///     assert(boost::hof::fold(max_f())(2, 3, 4, 5) == 5);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/function.hpp
+++ b/include/boost/hof/function.hpp
@@ -14,7 +14,7 @@
 /// Description
 /// -----------
 /// 
-
+/// 
 /// The `BOOST_HOF_STATIC_FUNCTION` macro allows initializing a function object from a
 /// `constexpr` expression. It uses the best practices as outlined in
 /// [N4381](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html).
@@ -35,24 +35,26 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct sum_f
+/// struct sum_f
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     BOOST_HOF_STATIC_FUNCTION(sum) = sum_f();
-///     BOOST_HOF_STATIC_FUNCTION(partial_sum) = boost::hof::partial(sum_f());
-/// 
-///     int main() {
-///         assert(sum(1, 2) == partial_sum(1)(2));
+///         return x+y;
 ///     }
+/// };
+/// 
+/// BOOST_HOF_STATIC_FUNCTION(sum) = sum_f();
+/// BOOST_HOF_STATIC_FUNCTION(partial_sum) = boost::hof::partial(sum_f());
+/// 
+/// int main() {
+///     assert(sum(1, 2) == partial_sum(1)(2));
+/// }
+/// ```
 /// 
 
 #include <boost/hof/reveal.hpp>

--- a/include/boost/hof/function_param_limit.hpp
+++ b/include/boost/hof/function_param_limit.hpp
@@ -24,10 +24,12 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     struct function_param_limit
-///     : std::integral_constant<std::size_t, ...>
-///     {};
+/// ```cpp
+/// template<class F>
+/// struct function_param_limit
+/// : std::integral_constant<std::size_t, ...>
+/// {};
+/// ```
 /// 
 /// See Also
 /// --------

--- a/include/boost/hof/identity.hpp
+++ b/include/boost/hof/identity.hpp
@@ -19,13 +19,17 @@
 /// Semantics
 /// ---------
 /// 
-///     assert(identity(x) == x);
+/// ```cpp
+/// assert(identity(x) == x);
+/// ```
 /// 
 /// Synopsis
 /// --------
 /// 
-///     template<class T>
-///     constexpr T identity(T&& x);
+/// ```cpp
+/// template<class T>
+/// constexpr T identity(T&& x);
+/// ```
 /// 
 
 #include <utility>

--- a/include/boost/hof/if.hpp
+++ b/include/boost/hof/if.hpp
@@ -24,11 +24,13 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class IntegralConstant>
-///     constexpr auto if_(IntegralConstant);
+/// ```cpp
+/// template<class IntegralConstant>
+/// constexpr auto if_(IntegralConstant);
 /// 
-///     template<bool B, class F>
-///     constexpr auto if_c(F);
+/// template<bool B, class F>
+/// constexpr auto if_c(F);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -45,25 +47,27 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct sum_f
+/// struct sum_f
+/// {
+///     template<class T>
+///     int operator()(T x, T y) const
 ///     {
-///         template<class T>
-///         int operator()(T x, T y) const
-///         {
-///             return boost::hof::first_of(
-///                 boost::hof::if_(std::is_integral<T>())(boost::hof::_ + boost::hof::_),
-///                 boost::hof::always(0)
-///             )(x, y);
-///         }
-///     };
-/// 
-///     int main() {
-///         assert(sum_f()(1, 2) == 3);
-///         assert(sum_f()("", "") == 0);
+///         return boost::hof::first_of(
+///             boost::hof::if_(std::is_integral<T>())(boost::hof::_ + boost::hof::_),
+///             boost::hof::always(0)
+///         )(x, y);
 ///     }
+/// };
+/// 
+/// int main() {
+///     assert(sum_f()(1, 2) == 3);
+///     assert(sum_f()("", "") == 0);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/implicit.hpp
+++ b/include/boost/hof/implicit.hpp
@@ -24,13 +24,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<template <class...> class F>
-///     class implicit<F>;
+/// ```cpp
+/// template<template <class...> class F>
+/// class implicit<F>;
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(T(implicit<F>()(xs...)) == F<T>()(xs...));
+/// ```cpp
+/// assert(T(implicit<F>()(xs...)) == F<T>()(xs...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -43,36 +47,38 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     template<class T>
-///     struct auto_caster
+/// template<class T>
+/// struct auto_caster
+/// {
+///     template<class U>
+///     T operator()(U x)
 ///     {
-///         template<class U>
-///         T operator()(U x)
-///         {
-///             return T(x);
-///         }
-///     };
-/// 
-///     static constexpr implicit<auto_caster> auto_cast = {};
-/// 
-///     struct auto_caster_foo
-///     {
-///         int i;
-///         explicit auto_caster_foo(int i_) : i(i_) {}
-/// 
-///     };
-/// 
-///     int main() {
-///         float f = 1.5;
-///         int i = auto_cast(f);
-///         auto_caster_foo x = auto_cast(1);
-///         assert(1 == i);
-///         assert(1 == x.i);
+///         return T(x);
 ///     }
+/// };
+/// 
+/// static constexpr implicit<auto_caster> auto_cast = {};
+/// 
+/// struct auto_caster_foo
+/// {
+///     int i;
+///     explicit auto_caster_foo(int i_) : i(i_) {}
+/// 
+/// };
+/// 
+/// int main() {
+///     float f = 1.5;
+///     int i = auto_cast(f);
+///     auto_caster_foo x = auto_cast(1);
+///     assert(1 == i);
+///     assert(1 == x.i);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/pack.hpp>

--- a/include/boost/hof/indirect.hpp
+++ b/include/boost/hof/indirect.hpp
@@ -19,13 +19,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr indirect_adaptor<F> indirect(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr indirect_adaptor<F> indirect(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(indirect(f)(xs...) == (*f)(xs...));
+/// ```cpp
+/// assert(indirect(f)(xs...) == (*f)(xs...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -38,24 +42,26 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     #include <memory>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// #include <memory>
+/// using namespace boost::hof;
 /// 
-///     struct sum
+/// struct sum
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         int r = indirect(std::make_unique<sum>())(3,2);
-///         assert(r == 5);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     int r = indirect(std::make_unique<sum>())(3,2);
+///     assert(r == 5);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/delegate.hpp>

--- a/include/boost/hof/infix.hpp
+++ b/include/boost/hof/infix.hpp
@@ -21,13 +21,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr infix_adaptor<F> infix(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr infix_adaptor<F> infix(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(x <infix(f)> y == f(x, y));
+/// ```cpp
+/// assert(x <infix(f)> y == f(x, y));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -43,39 +47,47 @@
 /// Infix operators have the precedence of relational operators. This means
 /// operators such as `+` or `*` have higher precedence:
 /// 
-///     assert((x + y <infix(f)> z) == ((x + y) <infix(f)> z));
-///     assert((x * y <infix(f)> z) == ((x * y) <infix(f)> z));
+/// ```cpp
+/// assert((x + y <infix(f)> z) == ((x + y) <infix(f)> z));
+/// assert((x * y <infix(f)> z) == ((x * y) <infix(f)> z));
+/// ```
 /// 
 /// However, operators such as `|` or `==` have lower precedence::
 /// 
-///     assert((x | y <infix(f)> z) == (x | (y <infix(f)> z)));
-///     assert((x == y <infix(f)> z) == (x == (y <infix(f)> z)));
+/// ```cpp
+/// assert((x | y <infix(f)> z) == (x | (y <infix(f)> z)));
+/// assert((x == y <infix(f)> z) == (x == (y <infix(f)> z)));
+/// ```
 /// 
 /// Also, infix operators have left-to-right associativity:
 /// 
-///     assert(x <infix(f)> y <infix(g)> z == ((x <infix(f)> y) <infix(g)> z));
+/// ```cpp
+/// assert(x <infix(f)> y <infix(g)> z == ((x <infix(f)> y) <infix(g)> z));
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct plus_f
+/// struct plus_f
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-///     
-///     int main() {
-///         constexpr infix_adaptor<plus_f> plus = {};
-///         int r = 3 <plus> 2;
-///         assert(r == 5);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     constexpr infix_adaptor<plus_f> plus = {};
+///     int r = 3 <plus> 2;
+///     assert(r == 5);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/delegate.hpp>

--- a/include/boost/hof/is_invocable.hpp
+++ b/include/boost/hof/is_invocable.hpp
@@ -27,26 +27,29 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F, class... Ts>
-///     struct is_invocable;
+/// ```cpp
+/// template<class F, class... Ts>
+/// struct is_invocable;
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// using namespace boost::hof;
 /// 
-///     struct is_invocable_class
+/// struct is_invocable_class
+/// {
+///     void operator()(int) const
 ///     {
-///         void operator()(int) const
-///         {
-///         }
-///     };
-///     static_assert(is_invocable<is_invocable_class, int>(), "Not callable");
+///     }
+/// };
+/// static_assert(is_invocable<is_invocable_class, int>(), "Not callable");
 /// 
-///     int main() {}
+/// int main() {}
+/// ```
 /// 
-
 
 #include <boost/hof/detail/can_be_called.hpp>
 #include <boost/hof/apply.hpp>

--- a/include/boost/hof/is_unpackable.hpp
+++ b/include/boost/hof/is_unpackable.hpp
@@ -17,18 +17,22 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class T>
-///     struct is_unpackable;
+/// ```cpp
+/// template<class T>
+/// struct is_unpackable;
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     int main() {
-///         static_assert(boost::hof::is_unpackable<std::tuple<int>>::value, "Failed");
-///     }
+/// int main() {
+///     static_assert(boost::hof::is_unpackable<std::tuple<int>>::value, "Failed");
+/// }
+/// ```
 /// 
 
 #include <boost/hof/unpack_sequence.hpp>

--- a/include/boost/hof/lambda.hpp
+++ b/include/boost/hof/lambda.hpp
@@ -20,17 +20,19 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     const constexpr auto add_one = BOOST_HOF_STATIC_LAMBDA(int x)
-///     {
-///         return x + 1;
-///     };
+/// const constexpr auto add_one = BOOST_HOF_STATIC_LAMBDA(int x)
+/// {
+///     return x + 1;
+/// };
 /// 
-///     int main() {
-///         assert(3 == add_one(2));
-///     }
+/// int main() {
+///     assert(3 == add_one(2));
+/// }
+/// ```
 /// 
 /// BOOST_HOF_STATIC_LAMBDA_FUNCTION
 /// ==========================
@@ -42,7 +44,7 @@
 /// function object that contains non-capturing lambdas. It also ensures that
 /// the global function object has a unique address across translation units.
 /// This helps prevent possible ODR-violations.
-///
+/// 
 /// By default, all functions defined with `BOOST_HOF_STATIC_LAMBDA_FUNCTION` use
 /// the `boost::hof::reveal` adaptor to improve error messages.
 /// 
@@ -53,16 +55,18 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     BOOST_HOF_STATIC_LAMBDA_FUNCTION(add_one) = [](int x)
-///     {
-///         return x + 1;
-///     };
-///     int main() {
-///         assert(3 == add_one(2));
-///     }
+/// BOOST_HOF_STATIC_LAMBDA_FUNCTION(add_one) = [](int x)
+/// {
+///     return x + 1;
+/// };
+/// int main() {
+///     assert(3 == add_one(2));
+/// }
+/// ```
 /// 
 
 #include <boost/hof/config.hpp>

--- a/include/boost/hof/lazy.hpp
+++ b/include/boost/hof/lazy.hpp
@@ -28,16 +28,20 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr lazy_adaptor<F> lazy(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr lazy_adaptor<F> lazy(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(lazy(f)(xs...) == std::bind(f, xs...))
-///     assert(lazy(f)(xs...)() == f(xs...))
-///     assert(lazy(f)(_1)(x) == f(x))
-///     assert(lazy(f)(lazy(g)(_1))(x) == f(g(x)))
+/// ```cpp
+/// assert(lazy(f)(xs...) == std::bind(f, xs...))
+/// assert(lazy(f)(xs...)() == f(xs...))
+/// assert(lazy(f)(_1)(x) == f(x))
+/// assert(lazy(f)(lazy(g)(_1))(x) == f(g(x)))
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -50,15 +54,17 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     int main() {
-///         auto add = [](auto x, auto y) { return x+y; };
-///         auto increment = lazy(add)(_1, 1);
-///         assert(increment(5) == 6);
-///     }
+/// int main() {
+///     auto add = [](auto x, auto y) { return x+y; };
+///     auto increment = lazy(add)(_1, 1);
+///     assert(increment(5) == 6);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/lift.hpp
+++ b/include/boost/hof/lift.hpp
@@ -32,27 +32,31 @@
 /// Synopsis
 /// --------
 /// 
-///     // Wrap the function in a generic lambda
-///     #define BOOST_HOF_LIFT(...)
+/// ```cpp
+/// // Wrap the function in a generic lambda
+/// #define BOOST_HOF_LIFT(...)
 /// 
-///     // Declare a class named `name` that will forward to the function
-///     #define BOOST_HOF_LIFT_CLASS(name, ...)
+/// // Declare a class named `name` that will forward to the function
+/// #define BOOST_HOF_LIFT_CLASS(name, ...)
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     #include <algorithm>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// #include <algorithm>
 /// 
-///     // Declare the class `max_f`
-///     BOOST_HOF_LIFT_CLASS(max_f, std::max);
+/// // Declare the class `max_f`
+/// BOOST_HOF_LIFT_CLASS(max_f, std::max);
 /// 
-///     int main() {
-///         auto my_max = BOOST_HOF_LIFT(std::max);
-///         assert(my_max(3, 4) == std::max(3, 4));
-///         assert(max_f()(3, 4) == std::max(3, 4));
-///     }
+/// int main() {
+///     auto my_max = BOOST_HOF_LIFT(std::max);
+///     assert(my_max(3, 4) == std::max(3, 4));
+///     assert(max_f()(3, 4) == std::max(3, 4));
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/delegate.hpp>

--- a/include/boost/hof/limit.hpp
+++ b/include/boost/hof/limit.hpp
@@ -24,11 +24,13 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class IntegralConstant>
-///     constexpr auto limit(IntegralConstant);
+/// ```cpp
+/// template<class IntegralConstant>
+/// constexpr auto limit(IntegralConstant);
 /// 
-///     template<std::size_t N, class F>
-///     constexpr auto limit_c(F);
+/// template<std::size_t N, class F>
+/// constexpr auto limit_c(F);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -45,23 +47,25 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct sum_f
+/// struct sum_f
+/// {
+///     template<class T>
+///     int operator()(T x, T y) const
 ///     {
-///         template<class T>
-///         int operator()(T x, T y) const
-///         {
-///             return x+y;
-///         }
-///     };
-///     BOOST_HOF_STATIC_FUNCTION(sum) = limit_c<2>(sum_f());
-/// 
-///     int main() {
-///         assert(3 == sum(1, 2));
+///         return x+y;
 ///     }
+/// };
+/// BOOST_HOF_STATIC_FUNCTION(sum) = limit_c<2>(sum_f());
+/// 
+/// int main() {
+///     assert(3 == sum(1, 2));
+/// }
+/// ```
 /// 
 /// See Also
 /// --------

--- a/include/boost/hof/match.hpp
+++ b/include/boost/hof/match.hpp
@@ -22,8 +22,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class... Fs>
-///     constexpr match_adaptor<Fs...> match(Fs...fs);
+/// ```cpp
+/// template<class... Fs>
+/// constexpr match_adaptor<Fs...> match(Fs...fs);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -36,34 +38,36 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// using namespace boost::hof;
 /// 
-///     struct int_class
+/// struct int_class
+/// {
+///     int operator()(int) const
 ///     {
-///         int operator()(int) const
-///         {
-///             return 1;
-///         }
-///     };
+///         return 1;
+///     }
+/// };
 /// 
-///     struct foo
-///     {};
+/// struct foo
+/// {};
 /// 
-///     struct foo_class
+/// struct foo_class
+/// {
+///     foo operator()(foo) const
 ///     {
-///         foo operator()(foo) const
-///         {
-///             return foo();
-///         }
-///     };
+///         return foo();
+///     }
+/// };
 /// 
-///     typedef match_adaptor<int_class, foo_class> fun;
+/// typedef match_adaptor<int_class, foo_class> fun;
 /// 
-///     static_assert(std::is_same<int, decltype(fun()(1))>::value, "Failed match");
-///     static_assert(std::is_same<foo, decltype(fun()(foo()))>::value, "Failed match");
+/// static_assert(std::is_same<int, decltype(fun()(1))>::value, "Failed match");
+/// static_assert(std::is_same<foo, decltype(fun()(foo()))>::value, "Failed match");
 /// 
-///     int main() {}
+/// int main() {}
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/mutable.hpp
+++ b/include/boost/hof/mutable.hpp
@@ -26,8 +26,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     mutable_adaptor<F> mutable_(F f)
+/// ```cpp
+/// template<class F>
+/// mutable_adaptor<F> mutable_(F f)
+/// ```
 /// 
 /// Requirements
 /// ------------

--- a/include/boost/hof/pack.hpp
+++ b/include/boost/hof/pack.hpp
@@ -22,51 +22,56 @@
 /// Synopsis
 /// --------
 /// 
-///     // Decay everything before capturing
-///     template<class... Ts>
-///     constexpr auto pack(Ts&&... xs);
+/// ```cpp
+/// // Decay everything before capturing
+/// template<class... Ts>
+/// constexpr auto pack(Ts&&... xs);
 /// 
-///     // Capture lvalues by reference and rvalue reference by reference
-///     template<class... Ts>
-///     constexpr auto pack_forward(Ts&&... xs);
+/// // Capture lvalues by reference and rvalue reference by reference
+/// template<class... Ts>
+/// constexpr auto pack_forward(Ts&&... xs);
 /// 
-///     // Capture lvalues by reference and rvalues by value.
-///     template<class... Ts>
-///     constexpr auto pack_basic(Ts&&... xs);
+/// // Capture lvalues by reference and rvalues by value.
+/// template<class... Ts>
+/// constexpr auto pack_basic(Ts&&... xs);
 /// 
-///     // Join multiple packs together
-///     template<class... Ts>
-///     constexpr auto pack_join(Ts&&... xs);
+/// // Join multiple packs together
+/// template<class... Ts>
+/// constexpr auto pack_join(Ts&&... xs);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(pack(xs...)(f) == f(xs...));
-///     assert(unpack(f)(pack(xs...)) == f(xs...));
+/// ```cpp
+/// assert(pack(xs...)(f) == f(xs...));
+/// assert(unpack(f)(pack(xs...)) == f(xs...));
 /// 
-///     assert(pack_join(pack(xs...), pack(ys...)) == pack(xs..., ys...));
-/// 
+/// assert(pack_join(pack(xs...), pack(ys...)) == pack(xs..., ys...));
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct sum
+/// struct sum
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         int r = pack(3, 2)(sum());
-///         assert(r == 5);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     int r = pack(3, 2)(sum());
+///     assert(r == 5);
+/// }
+/// ```
 /// 
 /// See Also
 /// --------

--- a/include/boost/hof/partial.hpp
+++ b/include/boost/hof/partial.hpp
@@ -25,13 +25,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr partial_adaptor<F> partial(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr partial_adaptor<F> partial(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(partial(f)(xs...)(ys...) == f(xs..., ys...));
+/// ```cpp
+/// assert(partial(f)(xs...)(ys...) == f(xs..., ys...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -44,22 +48,24 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct sum
+/// struct sum
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         assert(3 == partial(sum())(1)(2));
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     assert(3 == partial(sum())(1)(2));
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/pipable.hpp
+++ b/include/boost/hof/pipable.hpp
@@ -23,13 +23,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr pipable_adaptor<F> pipable(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr pipable_adaptor<F> pipable(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(x | pipable(f)(ys...) == f(x, ys...));
+/// ```cpp
+/// assert(x | pipable(f)(ys...) == f(x, ys...));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -42,23 +46,25 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct sum
+/// struct sum
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         assert(3 == (1 | pipable(sum())(2)));
-///         assert(3 == pipable(sum())(1, 2));
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     assert(3 == (1 | pipable(sum())(2)));
+///     assert(3 == pipable(sum())(1, 2));
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/placeholders.hpp
+++ b/include/boost/hof/placeholders.hpp
@@ -21,17 +21,19 @@
 /// Synopsis
 /// --------
 /// 
-///     namespace placeholders {
-///         placeholder<1> _1 = {};
-///         placeholder<2> _2 = {};
-///         placeholder<3> _3 = {};
-///         placeholder<4> _4 = {};
-///         placeholder<5> _5 = {};
-///         placeholder<6> _6 = {};
-///         placeholder<7> _7 = {};
-///         placeholder<8> _8 = {};
-///         placeholder<9> _9 = {};
-///     }
+/// ```cpp
+/// namespace placeholders {
+///     placeholder<1> _1 = {};
+///     placeholder<2> _2 = {};
+///     placeholder<3> _3 = {};
+///     placeholder<4> _4 = {};
+///     placeholder<5> _5 = {};
+///     placeholder<6> _6 = {};
+///     placeholder<7> _7 = {};
+///     placeholder<8> _8 = {};
+///     placeholder<9> _9 = {};
+/// }
+/// ```
 /// 
 /// Operators
 /// ---------
@@ -44,15 +46,16 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     int main() {
-///         auto sum = _1 + _2;
-///         assert(3 == sum(1, 2));
-///     }
-/// 
+/// int main() {
+///     auto sum = _1 + _2;
+///     assert(3 == sum(1, 2));
+/// }
+/// ```
 /// 
 /// unamed placeholder
 /// ==================
@@ -68,21 +71,25 @@
 /// Synopsis
 /// --------
 /// 
-///     namespace placeholders {
-///         /* unspecified */ _ = {};
-///     }
+/// ```cpp
+/// namespace placeholders {
+///     /* unspecified */ _ = {};
+/// }
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     int main() {
-///         auto sum = _ + _;
-///         assert(3 == sum(1, 2));
-///     }
+/// int main() {
+///     auto sum = _ + _;
+///     assert(3 == sum(1, 2));
+/// }
+/// ```
 /// 
 
 #include <boost/hof/returns.hpp>

--- a/include/boost/hof/proj.hpp
+++ b/include/boost/hof/proj.hpp
@@ -27,17 +27,21 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class Projection, class F>
-///     constexpr proj_adaptor<Projection, F> proj(Projection p, F f);
+/// ```cpp
+/// template<class Projection, class F>
+/// constexpr proj_adaptor<Projection, F> proj(Projection p, F f);
 /// 
-///     template<class Projection>
-///     constexpr proj_adaptor<Projection> proj(Projection p);
+/// template<class Projection>
+/// constexpr proj_adaptor<Projection> proj(Projection p);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(proj(p, f)(xs...) == f(p(xs)...));
-///     assert(proj(p)(xs...) == p(xs)...);
+/// ```cpp
+/// assert(proj(p, f)(xs...) == f(p(xs)...));
+/// assert(proj(p)(xs...) == p(xs)...);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -55,20 +59,22 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct foo
-///     {
-///         foo(int x_) : x(x_)
-///         {}
-///         int x;
-///     };
+/// struct foo
+/// {
+///     foo(int x_) : x(x_)
+///     {}
+///     int x;
+/// };
 /// 
-///     int main() {
-///         assert(boost::hof::proj(&foo::x, _ + _)(foo(1), foo(2)) == 3);
-///     }
+/// int main() {
+///     assert(boost::hof::proj(&foo::x, _ + _)(foo(1), foo(2)) == 3);
+/// }
+/// ```
 /// 
 /// References
 /// ----------
@@ -76,8 +82,6 @@
 /// * [Projections](Projections)
 /// * [Variadic print](<Variadic print>)
 /// 
-
-
 
 #include <utility>
 #include <boost/hof/always.hpp>

--- a/include/boost/hof/protect.hpp
+++ b/include/boost/hof/protect.hpp
@@ -24,13 +24,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     constexpr protect_adaptor<F> protect(F f);
+/// ```cpp
+/// template<class F>
+/// constexpr protect_adaptor<F> protect(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(lazy(f)(protect(lazy(g)(_1)))() == f(lazy(g)(_1)))
+/// ```cpp
+/// assert(lazy(f)(protect(lazy(g)(_1)))() == f(lazy(g)(_1)))
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -43,15 +47,17 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     int main() {
-///         auto lazy_id = lazy(identity)(_1);
-///         auto lazy_apply = lazy(apply)(protect(lazy_id), _1);
-///         assert(lazy_apply(3) == 3);
-///     }
+/// int main() {
+///     auto lazy_id = lazy(identity)(_1);
+///     auto lazy_apply = lazy(apply)(protect(lazy_id), _1);
+///     assert(lazy_apply(3) == 3);
+/// }
+/// ```
 /// 
 /// See Also
 /// --------

--- a/include/boost/hof/repeat.hpp
+++ b/include/boost/hof/repeat.hpp
@@ -21,16 +21,20 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class Integral>
-///     constexpr auto repeat(Integral);
+/// ```cpp
+/// template<class Integral>
+/// constexpr auto repeat(Integral);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(repeat(std::integral_constant<int, 0>{})(f)(xs...) == f(xs...));
-///     assert(repeat(std::integral_constant<int, 1>{})(f)(xs...) == f(f(xs...)));
-///     assert(repeat(0)(f)(xs...) == f(xs...));
-///     assert(repeat(1)(f)(xs...) == f(f(xs...)));
+/// ```cpp
+/// assert(repeat(std::integral_constant<int, 0>{})(f)(xs...) == f(xs...));
+/// assert(repeat(std::integral_constant<int, 1>{})(f)(xs...) == f(f(xs...)));
+/// assert(repeat(0)(f)(xs...) == f(xs...));
+/// assert(repeat(1)(f)(xs...) == f(f(xs...)));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -46,22 +50,24 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct increment
+/// struct increment
+/// {
+///     template<class T>
+///     constexpr T operator()(T x) const
 ///     {
-///         template<class T>
-///         constexpr T operator()(T x) const
-///         {
-///             return x + 1;
-///         }
-///     };
-/// 
-///     int main() {
-///         auto increment_by_5 = boost::hof::repeat(std::integral_constant<int, 5>())(increment());
-///         assert(increment_by_5(1) == 6);
+///         return x + 1;
 ///     }
+/// };
+/// 
+/// int main() {
+///     auto increment_by_5 = boost::hof::repeat(std::integral_constant<int, 5>())(increment());
+///     assert(increment_by_5(1) == 6);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/always.hpp>

--- a/include/boost/hof/repeat_while.hpp
+++ b/include/boost/hof/repeat_while.hpp
@@ -22,8 +22,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class Predicate>
-///     constexpr auto repeat_while(Predicate predicate);
+/// ```cpp
+/// template<class Predicate>
+/// constexpr auto repeat_while(Predicate predicate);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -36,35 +38,37 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct increment
+/// struct increment
+/// {
+///     template<class T>
+///     constexpr std::integral_constant<int, T::value + 1> operator()(T) const
 ///     {
-///         template<class T>
-///         constexpr std::integral_constant<int, T::value + 1> operator()(T) const
-///         {
-///             return std::integral_constant<int, T::value + 1>();
-///         }
-///     };
-/// 
-///     struct not_6
-///     {
-///         template<class T>
-///         constexpr std::integral_constant<bool, (T::value != 6)> 
-///         operator()(T) const
-///         {
-///             return std::integral_constant<bool, (T::value != 6)>();
-///         }
-///     };
-/// 
-///     typedef std::integral_constant<int, 1> one;
-///     typedef std::integral_constant<int, 6> six;
-/// 
-///     int main() {
-///         auto increment_until_6 = boost::hof::repeat_while(not_6())(increment());
-///         static_assert(std::is_same<six, decltype(increment_until_6(one()))>::value, "Error");
+///         return std::integral_constant<int, T::value + 1>();
 ///     }
+/// };
+/// 
+/// struct not_6
+/// {
+///     template<class T>
+///     constexpr std::integral_constant<bool, (T::value != 6)> 
+///     operator()(T) const
+///     {
+///         return std::integral_constant<bool, (T::value != 6)>();
+///     }
+/// };
+/// 
+/// typedef std::integral_constant<int, 1> one;
+/// typedef std::integral_constant<int, 6> six;
+/// 
+/// int main() {
+///     auto increment_until_6 = boost::hof::repeat_while(not_6())(increment());
+///     static_assert(std::is_same<six, decltype(increment_until_6(one()))>::value, "Error");
+/// }
+/// ```
 /// 
 
 #include <boost/hof/always.hpp>

--- a/include/boost/hof/result.hpp
+++ b/include/boost/hof/result.hpp
@@ -23,8 +23,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class Result, class F>
-///     constexpr result_adaptor<Result, F> result(F f);
+/// ```cpp
+/// template<class Result, class F>
+/// constexpr result_adaptor<Result, F> result(F f);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -37,22 +39,24 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct id
+/// struct id
+/// {
+///     template<class T>
+///     T operator()(T x) const
 ///     {
-///         template<class T>
-///         T operator()(T x) const
-///         {
-///             return x;
-///         }
-///     };
-/// 
-///     int main() {
-///         auto int_result = boost::hof::result<int>(id());
-///         static_assert(std::is_same<decltype(int_result(true)), int>::value, "Not the same type");
+///         return x;
 ///     }
+/// };
+/// 
+/// int main() {
+///     auto int_result = boost::hof::result<int>(id());
+///     static_assert(std::is_same<decltype(int_result(true)), int>::value, "Not the same type");
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/callable_base.hpp>

--- a/include/boost/hof/returns.hpp
+++ b/include/boost/hof/returns.hpp
@@ -27,22 +27,24 @@
 /// Synopsis
 /// --------
 /// 
-///     #define BOOST_HOF_RETURNS(...) 
-/// 
+/// ```cpp
+/// #define BOOST_HOF_RETURNS(...)
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     template<class T, class U>
-///     auto sum(T x, U y) BOOST_HOF_RETURNS(x+y);
+/// template<class T, class U>
+/// auto sum(T x, U y) BOOST_HOF_RETURNS(x+y);
 /// 
-///     int main() {
-///         assert(3 == sum(1, 2));
-///     }
-/// 
+/// int main() {
+///     assert(3 == sum(1, 2));
+/// }
+/// ```
 /// 
 /// Incomplete this
 /// ---------------
@@ -59,36 +61,38 @@
 /// Synopsis
 /// --------
 /// 
-///     // Declares the type of the `this` variable
-///     #define BOOST_HOF_RETURNS_CLASS(...) 
-///     // Used to refer to the `this` variable in the BOOST_HOF_RETURNS macro
-///     #define BOOST_HOF_THIS
-///     // Used to refer to the const `this` variable in the BOOST_HOF_RETURNS macro
-///     #define BOOST_HOF_CONST_THIS
-/// 
+/// ```cpp
+/// // Declares the type of the `this` variable
+/// #define BOOST_HOF_RETURNS_CLASS(...) 
+/// // Used to refer to the `this` variable in the BOOST_HOF_RETURNS macro
+/// #define BOOST_HOF_THIS
+/// // Used to refer to the const `this` variable in the BOOST_HOF_RETURNS macro
+/// #define BOOST_HOF_CONST_THIS
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct add_1
-///     {
-///         int a;
-///         add_1() : a(1) {}
-///         
-///         BOOST_HOF_RETURNS_CLASS(add_1);
-///         
-///         template<class T>
-///         auto operator()(T x) const 
-///         BOOST_HOF_RETURNS(x+BOOST_HOF_CONST_THIS->a);
-///     };
+/// struct add_1
+/// {
+///     int a;
+///     add_1() : a(1) {}
+///     
+///     BOOST_HOF_RETURNS_CLASS(add_1);
+///     
+///     template<class T>
+///     auto operator()(T x) const 
+///     BOOST_HOF_RETURNS(x+BOOST_HOF_CONST_THIS->a);
+/// };
 /// 
-///     int main() {
-///         assert(3 == add_1()(2));
-///     }
-/// 
+/// int main() {
+///     assert(3 == add_1()(2));
+/// }
+/// ```
 /// 
 /// Mangling overloads
 /// ------------------
@@ -104,18 +108,19 @@
 /// Synopsis
 /// --------
 /// 
-///     // Explicitly defines the type for name mangling
-///     #define BOOST_HOF_MANGLE_CAST(...) 
-///     // C cast for name mangling
-///     #define BOOST_HOF_RETURNS_C_CAST(...) 
-///     // Reinterpret cast for name mangling
-///     #define BOOST_HOF_RETURNS_REINTERPRET_CAST(...) 
-///     // Static cast for name mangling
-///     #define BOOST_HOF_RETURNS_STATIC_CAST(...) 
-///     // Construction for name mangling
-///     #define BOOST_HOF_RETURNS_CONSTRUCT(...) 
+/// ```cpp
+/// // Explicitly defines the type for name mangling
+/// #define BOOST_HOF_MANGLE_CAST(...) 
+/// // C cast for name mangling
+/// #define BOOST_HOF_RETURNS_C_CAST(...) 
+/// // Reinterpret cast for name mangling
+/// #define BOOST_HOF_RETURNS_REINTERPRET_CAST(...) 
+/// // Static cast for name mangling
+/// #define BOOST_HOF_RETURNS_STATIC_CAST(...) 
+/// // Construction for name mangling
+/// #define BOOST_HOF_RETURNS_CONSTRUCT(...)
+/// ```
 /// 
-
 
 #include <boost/hof/config.hpp>
 #include <utility>

--- a/include/boost/hof/reveal.hpp
+++ b/include/boost/hof/reveal.hpp
@@ -26,71 +26,79 @@
 /// 
 /// If we take the `print` example from the quick start guide like this:
 /// 
-///     namespace adl {
+/// ```cpp
+/// namespace adl {
 /// 
-///     using std::begin;
+/// using std::begin;
 /// 
-///     template<class R>
-///     auto adl_begin(R&& r) BOOST_HOF_RETURNS(begin(r));
+/// template<class R>
+/// auto adl_begin(R&& r) BOOST_HOF_RETURNS(begin(r));
+/// }
+/// 
+/// BOOST_HOF_STATIC_LAMBDA_FUNCTION(for_each_tuple) = [](const auto& sequence, auto f) BOOST_HOF_RETURNS
+/// (
+///     boost::hof::unpack(boost::hof::proj(f))(sequence)
+/// );
+/// 
+/// auto print = boost::hof::fix(boost::hof::first_of(
+///     [](auto, const auto& x) -> decltype(std::cout << x, void())
+///     {
+///         std::cout << x << std::endl;
+///     },
+///     [](auto self, const auto& range) -> decltype(self(*adl::adl_begin(range)), void())
+///     {
+///         for(const auto& x:range) self(x);
+///     },
+///     [](auto self, const auto& tuple) -> decltype(for_each_tuple(tuple, self), void())
+///     {
+///         return for_each_tuple(tuple, self);
 ///     }
-/// 
-///     BOOST_HOF_STATIC_LAMBDA_FUNCTION(for_each_tuple) = [](const auto& sequence, auto f) BOOST_HOF_RETURNS
-///     (
-///         boost::hof::unpack(boost::hof::proj(f))(sequence)
-///     );
-/// 
-///     auto print = boost::hof::fix(boost::hof::first_of(
-///         [](auto, const auto& x) -> decltype(std::cout << x, void())
-///         {
-///             std::cout << x << std::endl;
-///         },
-///         [](auto self, const auto& range) -> decltype(self(*adl::adl_begin(range)), void())
-///         {
-///             for(const auto& x:range) self(x);
-///         },
-///         [](auto self, const auto& tuple) -> decltype(for_each_tuple(tuple, self), void())
-///         {
-///             return for_each_tuple(tuple, self);
-///         }
-///     ));
+/// ));
+/// ```
 /// 
 /// Which prints numbers and vectors:
 /// 
-///     print(5);
+/// ```cpp
+/// print(5);
 /// 
-///     std::vector<int> v = { 1, 2, 3, 4 };
-///     print(v);
+/// std::vector<int> v = { 1, 2, 3, 4 };
+/// print(v);
+/// ```
 /// 
 /// However, if we pass a type that can't be printed, we get an error like
 /// this:
 /// 
-///     print.cpp:49:5: error: no matching function for call to object of type 'boost::hof::fix_adaptor<boost::hof::first_of_adaptor<(lambda at print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)> >'
-///         print(foo{});
-///         ^~~~~
-///     fix.hpp:158:5: note: candidate template ignored: substitution failure [with Ts = <foo>]: no matching function for call to object of type 'const boost::hof::first_of_adaptor<(lambda at
-///           print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)>'
-///         operator()(Ts&&... xs) const BOOST_HOF_SFINAE_RETURNS
+/// ```cpp
+/// print.cpp:49:5: error: no matching function for call to object of type 'boost::hof::fix_adaptor<boost::hof::first_of_adaptor<(lambda at print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)> >'
+///     print(foo{});
+///     ^~~~~
+/// fix.hpp:158:5: note: candidate template ignored: substitution failure [with Ts = <foo>]: no matching function for call to object of type 'const boost::hof::first_of_adaptor<(lambda at
+///       print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)>'
+///     operator()(Ts&&... xs) const BOOST_HOF_SFINAE_RETURNS
+/// ```
 /// 
 /// Which is short and gives very little information why it can't be called.
 /// It doesn't even show the overloads that were try. However, using the
 /// `reveal` adaptor we can get more info about the error like this:
 /// 
-///     print.cpp:49:5: error: no matching function for call to object of type 'boost::hof::reveal_adaptor<boost::hof::fix_adaptor<boost::hof::first_of_adaptor<(lambda at print.cpp:29:9), (lambda at print.cpp:33:9),
-///           (lambda at print.cpp:37:9)> >, boost::hof::fix_adaptor<boost::hof::first_of_adaptor<(lambda at print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)> > >'
-///         boost::hof::reveal(print)(foo{});
-///         ^~~~~~~~~~~~~~~~~~
-///     reveal.hpp:149:20: note: candidate template ignored: substitution failure [with Ts = <foo>, $1 = void]: no matching function for call to object of type '(lambda at print.cpp:29:9)'
-///         constexpr auto operator()(Ts&&... xs) const
-///                        ^
-///     reveal.hpp:149:20: note: candidate template ignored: substitution failure [with Ts = <foo>, $1 = void]: no matching function for call to object of type '(lambda at print.cpp:33:9)'
-///         constexpr auto operator()(Ts&&... xs) const
-///                        ^
-///     reveal.hpp:149:20: note: candidate template ignored: substitution failure [with Ts = <foo>, $1 = void]: no matching function for call to object of type '(lambda at print.cpp:37:9)'
-///         constexpr auto operator()(Ts&&... xs) const
-///                        ^
-///     fix.hpp:158:5: note: candidate template ignored: substitution failure [with Ts = <foo>]: no matching function for call to object of type 'const boost::hof::first_of_adaptor<(lambda at
-///           print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)>'
-///         operator()(Ts&&... xs) const BOOST_HOF_SFINAE_RETURNS
+/// ```cpp
+/// print.cpp:49:5: error: no matching function for call to object of type 'boost::hof::reveal_adaptor<boost::hof::fix_adaptor<boost::hof::first_of_adaptor<(lambda at print.cpp:29:9), (lambda at print.cpp:33:9),
+///       (lambda at print.cpp:37:9)> >, boost::hof::fix_adaptor<boost::hof::first_of_adaptor<(lambda at print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)> > >'
+///     boost::hof::reveal(print)(foo{});
+///     ^~~~~~~~~~~~~~~~~~
+/// reveal.hpp:149:20: note: candidate template ignored: substitution failure [with Ts = <foo>, $1 = void]: no matching function for call to object of type '(lambda at print.cpp:29:9)'
+///     constexpr auto operator()(Ts&&... xs) const
+///                    ^
+/// reveal.hpp:149:20: note: candidate template ignored: substitution failure [with Ts = <foo>, $1 = void]: no matching function for call to object of type '(lambda at print.cpp:33:9)'
+///     constexpr auto operator()(Ts&&... xs) const
+///                    ^
+/// reveal.hpp:149:20: note: candidate template ignored: substitution failure [with Ts = <foo>, $1 = void]: no matching function for call to object of type '(lambda at print.cpp:37:9)'
+///     constexpr auto operator()(Ts&&... xs) const
+///                    ^
+/// fix.hpp:158:5: note: candidate template ignored: substitution failure [with Ts = <foo>]: no matching function for call to object of type 'const boost::hof::first_of_adaptor<(lambda at
+///       print.cpp:29:9), (lambda at print.cpp:33:9), (lambda at print.cpp:37:9)>'
+///     operator()(Ts&&... xs) const BOOST_HOF_SFINAE_RETURNS
+/// ```
 /// 
 /// So now the error has a note for each of the lambda overloads it tried. Of
 /// course this can be improved even further by providing custom reporting of
@@ -99,8 +107,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     reveal_adaptor<F> reveal(F f);
+/// ```cpp
+/// template<class F>
+/// reveal_adaptor<F> reveal(F f);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -123,44 +133,48 @@
 /// Synopsis
 /// --------
 /// 
-///     // Report failure by instantiating the Template
-///     template<template<class...> class Template>
-///     struct as_failure;
+/// ```cpp
+/// // Report failure by instantiating the Template
+/// template<template<class...> class Template>
+/// struct as_failure;
 /// 
-///     // Report multiple falures
-///     template<class... Failures>
-///     struct with_failures;
+/// // Report multiple falures
+/// template<class... Failures>
+/// struct with_failures;
 /// 
-///     // Report the failure for each function
-///     template<class... Fs>
-///     struct failure_for;
+/// // Report the failure for each function
+/// template<class... Fs>
+/// struct failure_for;
 /// 
-///     // Get the failure of a function
-///     template<class F>
-///     struct get_failure;
+/// // Get the failure of a function
+/// template<class F>
+/// struct get_failure;
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct sum_f
-///     {
-///         template<class T, class U>
-///         using sum_failure = decltype(std::declval<T>()+std::declval<U>());
+/// struct sum_f
+/// {
+///     template<class T, class U>
+///     using sum_failure = decltype(std::declval<T>()+std::declval<U>());
 /// 
-///         struct failure
-///         : boost::hof::as_failure<sum_failure>
-///         {};
+///     struct failure
+///     : boost::hof::as_failure<sum_failure>
+///     {};
 /// 
-///         template<class T, class U>
-///         auto operator()(T x, U y) const BOOST_HOF_RETURNS(x+y);
-///     };
+///     template<class T, class U>
+///     auto operator()(T x, U y) const BOOST_HOF_RETURNS(x+y);
+/// };
 /// 
-///     int main() {
-///         assert(sum_f()(1, 2) == 3);
-///     }
+/// int main() {
+///     assert(sum_f()(1, 2) == 3);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/always.hpp>

--- a/include/boost/hof/reverse_fold.hpp
+++ b/include/boost/hof/reverse_fold.hpp
@@ -27,19 +27,23 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F, class State>
-///     constexpr reverse_fold_adaptor<F, State> reverse_fold(F f, State s);
+/// ```cpp
+/// template<class F, class State>
+/// constexpr reverse_fold_adaptor<F, State> reverse_fold(F f, State s);
 /// 
-///     template<class F>
-///     constexpr reverse_fold_adaptor<F> reverse_fold(F f);
+/// template<class F>
+/// constexpr reverse_fold_adaptor<F> reverse_fold(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(reverse_fold(f, z)() == z);
-///     assert(reverse_fold(f, z)(x, xs...) == f(reverse_fold(f, z)(xs...), x));
-///     assert(reverse_fold(f)(x) == x);
-///     assert(reverse_fold(f)(x, xs...) == f(reverse_fold(f)(xs...), x));
+/// ```cpp
+/// assert(reverse_fold(f, z)() == z);
+/// assert(reverse_fold(f, z)(x, xs...) == f(reverse_fold(f, z)(xs...), x));
+/// assert(reverse_fold(f)(x) == x);
+/// assert(reverse_fold(f)(x, xs...) == f(reverse_fold(f)(xs...), x));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -56,21 +60,23 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct max_f
+/// struct max_f
+/// {
+///     template<class T, class U>
+///     constexpr T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         constexpr T operator()(T x, U y) const
-///         {
-///             return x > y ? x : y;
-///         }
-///     };
-/// 
-///     int main() {
-///         assert(boost::hof::reverse_fold(max_f())(2, 3, 4, 5) == 5);
+///         return x > y ? x : y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     assert(boost::hof::reverse_fold(max_f())(2, 3, 4, 5) == 5);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/rotate.hpp
+++ b/include/boost/hof/rotate.hpp
@@ -20,13 +20,17 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     rotate_adaptor<F> rotate(F f);
+/// ```cpp
+/// template<class F>
+/// rotate_adaptor<F> rotate(F f);
+/// ```
 /// 
 /// Semantics
 /// ---------
 /// 
-///     assert(rotate(f)(x, xs...) == f(xs..., x));
+/// ```cpp
+/// assert(rotate(f)(x, xs...) == f(xs..., x));
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -39,13 +43,15 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     int main() {
-///         int r = boost::hof::rotate(boost::hof::_ - boost::hof::_)(2, 5);
-///         assert(r == 3);
-///     }
+/// int main() {
+///     int r = boost::hof::rotate(boost::hof::_ - boost::hof::_)(2, 5);
+///     assert(r == 3);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/result_of.hpp>

--- a/include/boost/hof/static.hpp
+++ b/include/boost/hof/static.hpp
@@ -24,8 +24,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     class static_;
+/// ```cpp
+/// template<class F>
+/// class static_;
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -38,29 +40,31 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     // In C++ this class can't be static-initialized, because of the non-
-///     // trivial default constructor.
-///     struct times_function
+/// // In C++ this class can't be static-initialized, because of the non-
+/// // trivial default constructor.
+/// struct times_function
+/// {
+///     double factor;
+///     times_function() : factor(2)
+///     {}
+///     template<class T>
+///     T operator()(T x) const
 ///     {
-///         double factor;
-///         times_function() : factor(2)
-///         {}
-///         template<class T>
-///         T operator()(T x) const
-///         {
-///             return x*factor;
-///         }
-///     };
-/// 
-///     static constexpr static_<times_function> times2 = {};
-/// 
-///     int main() {
-///         assert(6 == times2(3));
+///         return x*factor;
 ///     }
+/// };
+/// 
+/// static constexpr static_<times_function> times2 = {};
+/// 
+/// int main() {
+///     assert(6 == times2(3));
+/// }
+/// ```
 /// 
 
 #include <boost/hof/detail/result_of.hpp>

--- a/include/boost/hof/tap.hpp
+++ b/include/boost/hof/tap.hpp
@@ -22,8 +22,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class T, class F>
-///     pipable constexpr T tap(T&& x, const F& f);
+/// ```cpp
+/// template<class T, class F>
+/// pipable constexpr T tap(T&& x, const F& f);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -35,26 +37,28 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     #include <iostream>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// #include <iostream>
+/// using namespace boost::hof;
 /// 
-///     struct sum_f
+/// struct sum_f
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     const pipable_adaptor<sum_f> sum = {};
-///     int main() {
-///         // Prints 3
-///         int r = 1 | sum(2) | tap([](int i) { std::cout << i; }) | sum(2);
-///         assert(r == 5);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// const pipable_adaptor<sum_f> sum = {};
+/// int main() {
+///     // Prints 3
+///     int r = 1 | sum(2) | tap([](int i) { std::cout << i; }) | sum(2);
+///     assert(r == 5);
+/// }
+/// ```
 /// 
 
 #include <boost/hof/pipable.hpp>

--- a/include/boost/hof/unpack.hpp
+++ b/include/boost/hof/unpack.hpp
@@ -23,8 +23,10 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class F>
-///     unpack_adaptor<F> unpack(F f);
+/// ```cpp
+/// template<class F>
+/// unpack_adaptor<F> unpack(F f);
+/// ```
 /// 
 /// Requirements
 /// ------------
@@ -37,23 +39,25 @@
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
-///     using namespace boost::hof;
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
+/// using namespace boost::hof;
 /// 
-///     struct sum
+/// struct sum
+/// {
+///     template<class T, class U>
+///     T operator()(T x, U y) const
 ///     {
-///         template<class T, class U>
-///         T operator()(T x, U y) const
-///         {
-///             return x+y;
-///         }
-///     };
-/// 
-///     int main() {
-///         int r = unpack(sum())(std::make_tuple(3,2));
-///         assert(r == 5);
+///         return x+y;
 ///     }
+/// };
+/// 
+/// int main() {
+///     int r = unpack(sum())(std::make_tuple(3,2));
+///     assert(r == 5);
+/// }
+/// ```
 /// 
 /// References
 /// ----------

--- a/include/boost/hof/unpack_sequence.hpp
+++ b/include/boost/hof/unpack_sequence.hpp
@@ -19,35 +19,39 @@
 /// Synopsis
 /// --------
 /// 
-///     template<class Sequence, class=void>
-///     struct unpack_sequence;
+/// ```cpp
+/// template<class Sequence, class=void>
+/// struct unpack_sequence;
+/// ```
 /// 
 /// Example
 /// -------
 /// 
-///     #include <boost/hof.hpp>
-///     #include <cassert>
+/// ```cpp
+/// #include <boost/hof.hpp>
+/// #include <cassert>
 /// 
-///     struct my_sequence
+/// struct my_sequence
+/// {
+///     int x;
+///     int y;
+/// };
+/// 
+/// namespace boost { namespace hof {
+///     template<>
+///     struct unpack_sequence<my_sequence>
 ///     {
-///         int x;
-///         int y;
+///         template<class F, class Sequence>
+///         constexpr static auto apply(F&& f, Sequence&& s) BOOST_HOF_RETURNS
+///         (
+///             f(s.x, s.y)
+///         );
 ///     };
-///     
-///     namespace boost { namespace hof {
-///         template<>
-///         struct unpack_sequence<my_sequence>
-///         {
-///             template<class F, class Sequence>
-///             constexpr static auto apply(F&& f, Sequence&& s) BOOST_HOF_RETURNS
-///             (
-///                 f(s.x, s.y)
-///             );
-///         };
-///     }} // namespace boost::hof
+/// }} // namespace boost::hof
 /// 
-///     int main() {
-///     }
+/// int main() {
+/// }
+/// ```
 /// 
 /// See Also
 /// --------


### PR DESCRIPTION
Both the old and new Sphinx versions support fenced code blocks with backticks and the name of the highlighter. This is a way to configure the docs so they'll be compatible with myst-parser.  
The code that generated the conversion is here: https://gist.github.com/sdarwin/ef0964e135599b937dfde1de9c868dd2  
It's probably simpler and easier to run the transformation once and then it's done, rather than maintaining it in conf.py. Going forward, be sure to use the new syntax.